### PR TITLE
Sketch for dcp-community README and charter process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# Reminder:
+# - A leading slash means the pattern is anchored at the root.
+# - No leading slash means the pattern matches at any depth.
+
+# Python files
+*.pyc
+__pycache__/
+.mypy_cache/
+.tox/
+*.egg-info/
+/build/
+/dist/
+/.eggs/
+
+# Sphinx documentation
+/docs/_build/
+
+# IDE project files
+/.pydevproject
+
+# vim python-mode plugin
+/.ropeproject
+
+# IntelliJ IDEA / PyCharm project files
+/.idea
+/*.iml
+
+# JS/node/npm/web dev files
+node_modules
+npm-debug.log
+
+# OS X metadata files
+.DS_Store
+
+# Python coverage
+.coverage
+.coverage.*
+
+# Credential files
+/gcp-credentials.json
+/application_secrets.json
+
+# Temporary folder
+/tmp
+
+# Local environment configuration
+/environment.local
+/environment.*.local
+
+# Terraform files
+.terraform
+backend.tf
+providers.tf
+variables.tf
+
+/smoketest-*.tmp

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# community
+# Human Cell Atlas Data Coordination Platform community
+
+** Work in Progress **
+
+Welcome to the community!
+
+## Communicating
+
+To get started, [join the HumanCellAtlas Slack workspace](http://join-slack.humancellatlas.org/) to receive an invitation. 
+
+### Browse and join Slack channels:
+
+  - #general is for
+  - #dcp is for
+  - #ingestion-service is for
+  - #data-store is for
+  - #secondary analysis is for
+  - #data-portal is for
+  - ...
+
+## Community Governance
+### Oversight
+### Decision Making, Conflict Resolution, and Facilitation
+### Code of Conduct
+### Project ownership and the charter process
+### Enhancements and the RFC (Request for comments) process

--- a/README.md
+++ b/README.md
@@ -4,23 +4,9 @@
 
 Welcome to the community!
 
-## Communicating
-
-To get started, [join the HumanCellAtlas Slack workspace](http://join-slack.humancellatlas.org/) to receive an invitation. 
-
-### Browse and join Slack channels:
-
-  - #general is for
-  - #dcp is for
-  - #ingestion-service is for
-  - #data-store is for
-  - #secondary analysis is for
-  - #data-portal is for
-  - ...
 
 ## Community Governance
 ### Oversight
 ### Decision Making, Conflict Resolution, and Facilitation
-### Code of Conduct
-### Project ownership and the charter process
-### Enhancements and the RFC (Request for comments) process
+### [Proposing projects – the charter process](charters/README.md)
+### Proposing enhancements – the RFC process

--- a/charters/README.md
+++ b/charters/README.md
@@ -2,7 +2,7 @@
 
 Each HCA DCP project must have a charter that specifies its scope, responsibilities, and leadership roles.
 
-The charter process provides a simple and consistent path for new projects to be formed that align with the direction of the HCA DCP roadmap and its priorities.
+The charter process provides a simple and consistent path for new projects to be formed that align with the direction and priorities of the HCA DCP.
 
 
 ## What the process is

--- a/charters/README.md
+++ b/charters/README.md
@@ -12,7 +12,7 @@ The charter process provides a simple and consistent path for new projects to be
   - Fill in the charter with attention to detail
   - Submit a pull request. Add the "charter-proposed" label
   - Share a link to the pull request for community review on the HumanCellAtlas **#dcp** slack channel
-  - Feedback is added to the pull request comment thread by community members
+  - Feedback is added to the pull request comment thread by community members. The Science PM (or a delegate) reviews for appropriate oversight from HCA Science governance.
   - Update the pull request in response to feedback
   - Share a link to the pull request for approval on the HumanCellAtlas **#tech-architecture** slack channel when all feedback is addressed. Replace "charter-proposed" with "charter-final-review". 
   - The request will be discussed at the next meeting of the Technical Leads. If approved, the Leads replace "charter-final-review" with "charter-approved" and merge the pull request. If rejected, the Leads replace "charter-final-review" with "charter-rejected" and add a rationale to the pull request comment thread.

--- a/charters/README.md
+++ b/charters/README.md
@@ -1,0 +1,18 @@
+# Charter Guide
+
+Each HCA DCP project must have a charter that specifies its scope, responsibilities, and leadership roles.
+
+The charter process provides a simple and consistent path for new projects to be formed that align with the direction of the HCA DCP roadmap and its priorities.
+
+
+## What the process is
+  - Fork the HumanCellAtlas dcp-community repository
+  - Make a subdirectory named charters/`MYPROJECTNAME`
+  - Copy `charters/charter-template.md` to `charters/MYPROJECTNAME/charter.md`
+  - Fill in the charter with attention to detail
+  - Submit a pull request. Add the "charter-proposed" label
+  - Share a link to the pull request for community review on the HumanCellAtlas **#dcp** slack channel
+  - Feedback is added to the pull request comment thread by community members
+  - Update the pull request in response to feedback
+  - Share a link to the pull request for approval on the HumanCellAtlas **#tech-architecture** slack channel when all feedback is addressed. Replace "charter-proposed" with "charter-final-review". 
+  - The request will be discussed at the next meeting of the Technical Leads. If approved, the Leads replace "charter-final-review" with "charter-approved" and merge the pull request. If rejected, the Leads replace "charter-final-review" with "charter-rejected" and add a rationale to the pull request comment thread.

--- a/charters/charter-template.md
+++ b/charters/charter-template.md
@@ -8,6 +8,10 @@
 
 ## In-scope
 
+### Scientific "guardrails" [Optional]
+
+_Describe recommended or mandated oversight from HCA Science governance to ensure that the charter addresses the needs of the scientific community._
+
 ## Out-of-scope
 
 ## Milestones

--- a/charters/charter-template.md
+++ b/charters/charter-template.md
@@ -18,6 +18,8 @@ _Describe recommended or mandated oversight from HCA Science governance to ensur
 
 ## Roles
 
+Recommended format for Roles: `[Name](mailto:username@example.com)`
+
 ### Project Lead
 
 ### Product Owner
@@ -27,8 +29,6 @@ _Describe recommended or mandated oversight from HCA Science governance to ensur
 
 ## Communication
 
-### Slack Channel(s)
-### Mailing list(s)
-### Discussion Forum(s)
+_List the Slack Channels, Mailing Lists, and/or Discussion Forums for the Project and describe their purpose._
 
 ## Github repositories

--- a/charters/charter-template.md
+++ b/charters/charter-template.md
@@ -1,0 +1,30 @@
+
+# Project Name
+
+
+## Description
+
+## Objective
+
+## In-scope
+
+## Out-of-scope
+
+## Milestones
+
+## Roles
+
+### Project Lead
+
+### Product Owner
+
+### Technical Lead
+
+
+## Communication
+
+### Slack Channel(s)
+### Mailing list(s)
+### Discussion Forum(s)
+
+## Github repositories


### PR DESCRIPTION
There are a number of teams interested in writing charters for existing projects or proposing new projects. This is an early draft to unblock experimentation and receive feedback on the process and template. I'm especially curious if the notification workflow can be simplified to rely only on github queries and notifications rather than slack. The lack of forums or mailing lists limit our communication options at the moment. It may also be helpful to create a tech-architecture github team to be assigned as the reviewer.

**Open issues**:
* [The value of milestones in charters](https://github.com/HumanCellAtlas/dcp-community/pull/1#discussion_r203871021)
* [Non-technical or process charters](https://github.com/HumanCellAtlas/dcp-community/pull/1#discussion_r203919084)

**Bikesheds**:
* [Product owners or PMs?](https://github.com/HumanCellAtlas/dcp-community/pull/1#discussion_r204457066)
* [Product, Project, Module, Component?](https://github.com/HumanCellAtlas/dcp-community/pull/1#discussion_r204456321)

**Pending non-editorial changes:**
* Add Science PM review to ensure _alignment with HCA Governance_ to charter process
* Add `Scientific guardrails` section to charter template