### PR TITLE
Query Service Charter

### DIFF
--- a/charters/QueryService/charter.md
+++ b/charters/QueryService/charter.md
@@ -45,7 +45,7 @@ kj
 * Search user interface, search application and/or analysis application work
 * Upkeep and improvement of existing indexers or ETL layers within DSS
 
-## Milestones
+## Milestones and Deliverables
 
 * **EOY 2018**
     * Architectural work done

--- a/charters/QueryService/charter.md
+++ b/charters/QueryService/charter.md
@@ -1,6 +1,4 @@
-
 # Query Service
-
 
 ## Description
 The Query Service is an Application Programming Interface (API) for querying Human Cell Atlas (HCA) bundle metadata with intuitive query syntax.
@@ -14,7 +12,7 @@ Services the Query Module provides may complement or subsume the current search 
 1. Develop a scalable public API for external indexing and other DSS event consumers
 1. Deploy all query systems as stand-alone, modular services
 1. Make DCP index and query systems agnostic to DCP schema evolution
-kj
+
 ## In-scope
 * Common index event bus and deployment infrastructure
     * Finalize support for multiple metadata indexers in DSS

--- a/charters/QueryService/charter.md
+++ b/charters/QueryService/charter.md
@@ -20,31 +20,27 @@ The Query Service is an Application Programming Interface (API) for querying Hum
     * Expose event bus for bundle lifecycle event subscriptions
     * Scalable, fault-tolerant queuing mechanism: Amazon Web Services (AWS) Simple Queuing Service (SQS) push or similar
 * Query access service API and query language
-    * Define public DSS API for modular, pluggable query engines, and hand off to DSS team for long-term ownership (this includes API to trigger index/query processing, and to handle end-user queries)
-    * In collaboration with Expression Service project, determine how Query and consumer API interact and are made complementary
-    * Explore technical methods of isolating index and query systems from metadata schema evolution
+    * Public API for modular query engine plugins
+    * In collaboration with the Expression Matrix Service, determine how Query and consumer API interact and are made complementary
 * ElasticSearch search engine
-    * Migrate ES engine to pluggable interface, and factor into separate DCP service
+    * Stand-alone ES search service, integrated into search plugin interface
     * Improve isolation from metadata schema evolution
 * Structured Query Language (SQL) query engine
+    * Stand-alone SQL query service, integrated into search plugin interface
     * SQL metadata query prototype and pilot release
         * Socialize with community, investigate use cases, and determine utility of SQL query for these use cases
         * If prototype is viable, implement on the pluggable API, and launch as separate DCP service
-        * Implementation details
-            * Database service configuration and deployment infrastructure
-            * API front-end
-            * ETL layer and database schema
-            * Event handler that adds and removes bundle metadata from the index
-            * Unit, integration, and scale tests
+    * Database service configuration and deployment infrastructure
+    * ETL layer and database schema design
+* Documentation
     * Documentation for API and query language use with metadata
     * Demonstration use of service; developer example code to enable fast and easy third party adoption of API
+* UX Research and Feedback
+    * UX validation of API and query language with tertiary analysis community
     * Provide feedback to DCP about public API suitability in building layered services (e.g. can a new Query microservice be built using only public DSS API?)
 
-### Scientific "guardrails"
-* UX validation of API and query language with tertiary analysis community
-
 ## Out-of-scope
-* Search user interface (UI), search app and/or tertiary analysis work
+* Search user interface, search app and/or tertiary analysis work
 * GraphQL or other "query" languages or environments (ES and SQL should be sufficient to prove utility of design)
 * Upkeep and improvement of existing ES indexer ETL layer
 

--- a/charters/QueryService/charter.md
+++ b/charters/QueryService/charter.md
@@ -24,7 +24,7 @@ The Query Service is an Application Programming Interface (API) for querying Hum
     * In collaboration with the Expression Matrix Service, determine how Query and consumer API interact and are made complementary
 * ElasticSearch search engine
     * Stand-alone ES search service, integrated into search plugin interface
-    * Improve isolation from metadata schema evolution
+    * Increase isolation from metadata schema evolution
 * Structured Query Language (SQL) query engine
     * Stand-alone SQL query service, integrated into search plugin interface
     * SQL metadata query prototype and pilot release
@@ -36,24 +36,24 @@ The Query Service is an Application Programming Interface (API) for querying Hum
     * Documentation for API and query language use with metadata
     * Demonstration use of service; developer example code to enable fast and easy third party adoption of API
 * UX Research and Feedback
-    * UX validation of API and query language with tertiary analysis community
+    * UX validation of API and query language with [tertiary portal](https://www.humancellatlas.org/data-sharing) community
     * Provide feedback to DCP about public API suitability in building layered services (e.g. can a new Query microservice be built using only public DSS API?)
 
 ## Out-of-scope
-* Search user interface, search app and/or tertiary analysis work
+* Search user interface, search app and/or tertiary portal work
 * GraphQL or other "query" languages or environments (ES and SQL should be sufficient to prove utility of design)
 * Upkeep and improvement of existing ES indexer ETL layer
 
 ## Milestones
-* **EOY 2018** - architectural work done, ES migrated to public API, improved resilience to metadata schema evolution.
-* **Early 2019** - pilot/preview implementation of SQL query framework; feature complete, suitable for limited use, but not scalable
-* **Mid-2019** - performant, highly scalable version, suitable for interactive data serving across entire HCA data corpus
+* **EOY 2018** - Architectural work done, pilot/preview implementation of SQL query framework; feature complete, suitable for limited use, but not scalable
+* **Early 2019** - ES migrated to public API, improved resilience to metadata schema evolution
+* **Mid-2019** - Performant, highly scalable version, suitable for interactive data serving across entire HCA data corpus
 
 
 ## Roles
 
 ### Project Lead
-[Genevieve Halliburton](mailto:ghaliburton@chanzuckerberg.com)
+[Genevieve Haliburton](mailto:ghaliburton@chanzuckerberg.com)
 
 ### Product Owner
 [Matt Weiden](mailto:mweiden@chanzuckerberg.com)

--- a/charters/QueryService/charter.md
+++ b/charters/QueryService/charter.md
@@ -3,9 +3,9 @@
 
 
 ## Description
-The Query Service is an Application Programming Interface (API) for querying Human Cell Atlas (HCA) bundle metadata with intuitive query syntax. The first iteration of the Query Service Module will investigate [ElasticSearch (ES) Query Language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html) and  [Structured Query Language (SQL)](https://en.wikipedia.org/wiki/SQL).
+The Query Service is an Application Programming Interface (API) for querying Human Cell Atlas (HCA) bundle metadata with intuitive query syntax.
 
-Services the Query Module provides may complement or subsume the current ES search functionality in the Data Storage Service (DSS).
+Services the Query Module provides may complement or subsume the current search functionality in the Data Storage Service (DSS).
 
 ## Objectives
 1. Build, operate, and maintain a metadata API query service that allows a variety of queries to be performed against bundle metadata stored in HCA Data Coordination Platform (DCP) DSS
@@ -14,42 +14,48 @@ Services the Query Module provides may complement or subsume the current ES sear
 1. Develop a scalable public API for external indexing and other DSS event consumers
 1. Deploy all query systems as stand-alone, modular services
 1. Make DCP index and query systems agnostic to DCP schema evolution
-
+kj
 ## In-scope
 * Common index event bus and deployment infrastructure
     * Finalize support for multiple metadata indexers in DSS
     * Expose event bus for bundle lifecycle event subscriptions
     * Scalable, fault-tolerant queuing mechanism for loading bundle lifecycle events
-* Query access service API and query language
-    * Public API for modular query engine plugins
-    * In collaboration with the Expression Matrix Service, determine how Query and consumer API interact and are made complementary
-* ElasticSearch search engine
+* Provide new iteration of or replace DSS [ElasticSearch (ES)](https://www.elastic.co) index and [query language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html)
     * Stand-alone ES search service, integrated into search plugin interface
     * Increase isolation from metadata schema evolution
-* Structured Query Language (SQL) query engine
+* Investigate new index technologies that provide [Structured Query Language (SQL)](https://en.wikipedia.org/wiki/SQL)
     * Stand-alone SQL query service, integrated into search plugin interface
     * SQL metadata query prototype and pilot release
         * Socialize with community, investigate use cases, and determine utility of SQL query for these use cases
         * If prototype is viable, implement on the pluggable API, and launch as separate DCP service
     * Database service configuration and deployment infrastructure
     * ETL layer and database schema design
+* Query access service API and query language
+    * Public API for modular query engine plugins
+    * In collaboration with the Expression Matrix Service, determine how Query and consumer API interact and are made complementary
 * Documentation
     * Documentation for API and query language use with metadata
     * Demonstration use of service; developer example code to enable fast and easy third party adoption of API
 * UX Research and Feedback
-    * UX validation of API and query language with [tertiary portal](https://www.humancellatlas.org/data-sharing) community
+    * UX validation of API and query language with [analysis application](https://www.humancellatlas.org/data-sharing) community
     * Provide feedback to DCP about public API suitability in building layered services (e.g. can a new Query microservice be built using only public DSS API?)
     * Provide feedback to the metadata group on schema changes that could support intuitive queries of the metadata
 
 ## Out-of-scope
-* Search user interface, search app and/or tertiary portal work
-* GraphQL or other "query" languages or environments (ES and SQL should be sufficient to prove utility of design)
-* Upkeep and improvement of existing ES indexer ETL layer
+* Search user interface, search application and/or analysis application work
+* Upkeep and improvement of existing indexers or ETL layers within DSS
 
 ## Milestones
-* **EOY 2018** - Architectural work done, pilot/preview implementation of SQL query framework; feature complete, suitable for limited use, but not scalable
-* **Early 2019** - DSS ES migrated to public API, improved resilience to metadata schema evolution
-* **Mid-2019** - Performant, highly scalable version, suitable for interactive data serving across entire HCA data corpus
+
+* **EOY 2018**
+    * Architectural work done
+    * pilot/preview implementation of SQL query framework
+    * feature complete, suitable for use in UX research, but not scalable
+* **Early 2019**
+    * DSS ES migrated to public API
+    * improved resilience to metadata schema evolution
+* **Mid-2019**
+    * Performant, highly scalable version, suitable for interactive data serving across entire HCA data corpus
 
 
 ## Roles

--- a/charters/QueryService/charter.md
+++ b/charters/QueryService/charter.md
@@ -70,6 +70,8 @@ Services the Query Module provides may complement or subsume the current search 
 
 ## Communication
 
+Team email: dcp-query-service-team@data.humancellatlas.org
+
 ### Slack Channels
 HumanCellAtlas/query-service: Discussion of query service
 

--- a/charters/QueryService/charter.md
+++ b/charters/QueryService/charter.md
@@ -1,0 +1,75 @@
+
+# Query Service
+
+
+## Description
+The Query Service is an Application Programming Interface (API) for querying Human Cell Atlas (HCA) bundle metadata with different query languages.
+
+## Objectives
+1. Build, operate, and maintain a metadata API query service that allows a variety of queries to be performed against bundle metadata stored in HCA Data Coordination Platform (DCP) Data Storage Service (DSS)
+1. Develop a query language specification and metadata Extract, Transform, Load (ETL) pattern to accommodate intuitive querying
+1. Conduct user experience (UX) research to validate query language usability, understand remaining usability gaps in DCP data searchability and discoverability
+1. Develop a scalable public API for external indexing and other DSS event consumers
+1. Migrate existing ElasticSearch (ES) query subsystem to this public API
+1. Deploy all query systems as stand-alone, modular services
+1. Make DCP index and query systems agnostic to DCP schema evolution
+
+## In-scope
+* Common index event bus and deployment infrastructure
+    * Finalize support for multiple metadata indexers in DSS
+    * Expose event bus for bundle lifecycle event subscriptions
+    * Scalable, fault-tolerant queuing mechanism: Amazon Web Services (AWS) Simple Queuing Service (SQS) push or similar
+* Query access service API and query language
+    * Define public DSS API for modular, pluggable query engines, and hand off to DSS team for long-term ownership (this includes API to trigger index/query processing, and to handle end-user queries)
+    * In collaboration with Expression Service project, determine how Query and consumer API interact and are made complementary
+    * Explore technical methods of isolating index and query systems from metadata schema evolution
+* ElasticSearch search engine
+    * Migrate ES engine to pluggable interface, and factor into separate DCP service
+    * Improve isolation from metadata schema evolution
+* Structured Query Language (SQL) query engine
+    * SQL metadata query prototype and pilot release
+        * Socialize with community, investigate use cases, and determine utility of SQL query for these use cases
+        * If prototype is viable, implement on the pluggable API, and launch as separate DCP service
+        * Implementation details
+            * Database service configuration and deployment infrastructure
+            * API front-end
+            * ETL layer and database schema
+            * Event handler that adds and removes bundle metadata from the index
+            * Unit, integration, and scale tests
+    * Documentation for API and query language use with metadata
+    * Demonstration use of service; developer example code to enable fast and easy third party adoption of API
+    * Provide feedback to DCP about public API suitability in building layered services (e.g. can a new Query microservice be built using only public DSS API?)
+
+### Scientific "guardrails"
+* UX validation of API and query language with tertiary analysis community
+
+## Out-of-scope
+* Search user interface (UI), search app and/or tertiary analysis work
+* GraphQL or other "query" languages or environments (ES and SQL should be sufficient to prove utility of design)
+* Upkeep and improvement of existing ES indexer ETL layer
+
+## Milestones
+* **EOY 2018** - architectural work done, ES migrated to public API, improved resilience to metadata schema evolution.
+* **Early 2019** - pilot/preview implementation of SQL query framework; feature complete, suitable for limited use, but not scalable
+* **Mid-2019** - performant, highly scalable version, suitable for interactive data serving across entire HCA data corpus
+
+
+## Roles
+
+### Project Lead
+[Genevieve Halliburton](mailto:ghaliburton@chanzuckerberg.com)
+
+### Product Owner
+[Matt Weiden](mailto:mweiden@chanzuckerberg.com)
+
+### Technical Lead
+[Andrey Kislyuk](mailto:akislyuk@chanzuckerberg.com)
+
+
+## Communication
+
+### Slack Channels
+HumanCellAtlas/query-service: Discussion of query service
+
+## Github repositories
+* https://github.com/HumanCellAtlas/query-service

--- a/charters/QueryService/charter.md
+++ b/charters/QueryService/charter.md
@@ -13,6 +13,14 @@ Services the Query Module provides may complement or subsume the current search 
 1. Deploy all query systems as stand-alone, modular services
 1. Make DCP index and query systems agnostic to DCP schema evolution
 
+### Users
+
+Query Service features will be developed with use cases of the following users in mind.
+
+* Bioinformaticians
+* Computational Biologists
+* Portal Developers
+
 ## In-scope
 * Common index event bus and deployment infrastructure
     * Finalize support for multiple metadata indexers in DSS
@@ -21,9 +29,9 @@ Services the Query Module provides may complement or subsume the current search 
 * Provide new iteration of or replace DSS [ElasticSearch (ES)](https://www.elastic.co) index and [query language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html)
     * Stand-alone ES search service, integrated into search plugin interface
     * Increase isolation from metadata schema evolution
-* Investigate new index technologies that provide [Structured Query Language (SQL)](https://en.wikipedia.org/wiki/SQL)
-    * Stand-alone SQL query service, integrated into search plugin interface
-    * SQL metadata query prototype and pilot release
+* Investigate new index technologies that provide intuitive queries of HCA metadata
+    * Stand-alone query service, integrated into search plugin interface
+    * [Structured Query Language (SQL)](https://en.wikipedia.org/wiki/SQL) metadata query prototype and pilot release
         * Socialize with community, investigate use cases, and determine utility of SQL query for these use cases
         * If prototype is viable, implement on the pluggable API, and launch as separate DCP service
     * Database service configuration and deployment infrastructure

--- a/charters/QueryService/charter.md
+++ b/charters/QueryService/charter.md
@@ -3,14 +3,15 @@
 
 
 ## Description
-The Query Service is an Application Programming Interface (API) for querying Human Cell Atlas (HCA) bundle metadata with different query languages.
+The Query Service is an Application Programming Interface (API) for querying Human Cell Atlas (HCA) bundle metadata with intuitive query syntax. The first iteration of the Query Service Module will investigate [ElasticSearch (ES) Query Language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html) and  [Structured Query Language (SQL)](https://en.wikipedia.org/wiki/SQL).
+
+Services the Query Module provides may complement or subsume the current ES search functionality in the Data Storage Service (DSS).
 
 ## Objectives
-1. Build, operate, and maintain a metadata API query service that allows a variety of queries to be performed against bundle metadata stored in HCA Data Coordination Platform (DCP) Data Storage Service (DSS)
-1. Develop a query language specification and metadata Extract, Transform, Load (ETL) pattern to accommodate intuitive querying
+1. Build, operate, and maintain a metadata API query service that allows a variety of queries to be performed against bundle metadata stored in HCA Data Coordination Platform (DCP) DSS
+1. Develop a query language specification for intuitive querying of HCA metadata
 1. Conduct user experience (UX) research to validate query language usability, understand remaining usability gaps in DCP data searchability and discoverability
 1. Develop a scalable public API for external indexing and other DSS event consumers
-1. Migrate existing ElasticSearch (ES) query subsystem to this public API
 1. Deploy all query systems as stand-alone, modular services
 1. Make DCP index and query systems agnostic to DCP schema evolution
 
@@ -18,7 +19,7 @@ The Query Service is an Application Programming Interface (API) for querying Hum
 * Common index event bus and deployment infrastructure
     * Finalize support for multiple metadata indexers in DSS
     * Expose event bus for bundle lifecycle event subscriptions
-    * Scalable, fault-tolerant queuing mechanism: Amazon Web Services (AWS) Simple Queuing Service (SQS) push or similar
+    * Scalable, fault-tolerant queuing mechanism for loading bundle lifecycle events
 * Query access service API and query language
     * Public API for modular query engine plugins
     * In collaboration with the Expression Matrix Service, determine how Query and consumer API interact and are made complementary
@@ -38,6 +39,7 @@ The Query Service is an Application Programming Interface (API) for querying Hum
 * UX Research and Feedback
     * UX validation of API and query language with [tertiary portal](https://www.humancellatlas.org/data-sharing) community
     * Provide feedback to DCP about public API suitability in building layered services (e.g. can a new Query microservice be built using only public DSS API?)
+    * Provide feedback to the metadata group on schema changes that could support intuitive queries of the metadata
 
 ## Out-of-scope
 * Search user interface, search app and/or tertiary portal work
@@ -46,7 +48,7 @@ The Query Service is an Application Programming Interface (API) for querying Hum
 
 ## Milestones
 * **EOY 2018** - Architectural work done, pilot/preview implementation of SQL query framework; feature complete, suitable for limited use, but not scalable
-* **Early 2019** - ES migrated to public API, improved resilience to metadata schema evolution
+* **Early 2019** - DSS ES migrated to public API, improved resilience to metadata schema evolution
 * **Mid-2019** - Performant, highly scalable version, suitable for interactive data serving across entire HCA data corpus
 
 

--- a/charters/QueryService/charter.md
+++ b/charters/QueryService/charter.md
@@ -37,7 +37,7 @@ kj
     * Documentation for API and query language use with metadata
     * Demonstration use of service; developer example code to enable fast and easy third party adoption of API
 * UX Research and Feedback
-    * UX validation of API and query language with [analysis application](https://www.humancellatlas.org/data-sharing) community
+    * UX validation of API and query language with the analysis application community
     * Provide feedback to DCP about public API suitability in building layered services (e.g. can a new Query microservice be built using only public DSS API?)
     * Provide feedback to the metadata group on schema changes that could support intuitive queries of the metadata
 

--- a/charters/QueryService/charter.md
+++ b/charters/QueryService/charter.md
@@ -7,7 +7,7 @@ Services the Query Module provides may complement or subsume the current search 
 
 ## Objectives
 1. Build, operate, and maintain a metadata API query service that allows a variety of queries to be performed against bundle metadata stored in HCA Data Coordination Platform (DCP) DSS
-1. Develop a query language specification for intuitive querying of HCA metadata
+1. Develop a query language specification for intuitive querying of HCA metadata by DCP developers and tertiary analysis app developers
 1. Conduct user experience (UX) research to validate query language usability, understand remaining usability gaps in DCP data searchability and discoverability
 1. Develop a scalable public API for external indexing and other DSS event consumers
 1. Deploy all query systems as stand-alone, modular services


### PR DESCRIPTION
**Approved at the 10/11/18 DCP Architecture meeting**

This PR proposes the charter for the Query Service Module.

The Query Service is an Application Programming Interface (API) for querying Human Cell Atlas (HCA) bundle metadata with different query languages.