### PR TITLE
DCP Architecture Team charter

### DIFF
--- a/charters/Architecture/charter.md
+++ b/charters/Architecture/charter.md
@@ -2,14 +2,17 @@
 
 ## Description
 
-The Data Coordination Platform (DCP) Architecture Team is responsible for the technical oversight of the DCP, including identifying and addressing *cross-cutting* architectural concerns across DCP projects.
+The Data Coordination Platform (DCP) Architecture Team is responsible for the technical oversight of the DCP,
+including identifying and addressing *cross-cutting* architectural concerns across DCP projects.
 
-The core team is composed of *Technical Leads* representing each DCP component to ensure a diversity of skills and views needed for community technical decision-making. 
+The core team is composed of *Technical Leads* representing each DCP component to ensure a diversity of skills and
+views needed for community technical decision-making. 
 
 ## In-scope
 Strategic responsibilities
 * Set overall **technical** direction for the DCP
-* Publish Architecture Requests for Comments (RFCs) documenting technical debt that impacts delivery of DCP as an integrated system and must be addressed by PM product plans
+* Publish Architecture Requests for Comments (RFCs) documenting technical debt that impacts delivery of DCP as an
+  integrated system and must be addressed by PM product plans
 * Review and provide final approval for technical charters for DCP projects
 * Review and provide final approval for cross-component RFC(s)
     * Available to mentor on all RFC designs

--- a/charters/Architecture/charter.md
+++ b/charters/Architecture/charter.md
@@ -1,0 +1,35 @@
+# Architecture++
+
+## Description
+
+Architecture++ is responsible for the technical oversight of the Data Coordination Platform (DCP), including identifying and addressing *cross-cutting* architectural concerns across DCP components.
+
+The core team is composed of *Technical Leads* representing each DCP component to ensure a diversity of skills and views needed for community technical decision-making. 
+
+## In-scope
+Strategic responsibilities
+* Set overall **technical** direction for the DCP
+* Publish an annual Architecture RFC documenting technical debt that needs to be addressed during roadmap planning by DCP PM++
+* Review and approve technical charters for DCP components
+* Review and approve cross-component RFC(s)
+    * Available to mentor on all RFC designs
+* Develop technical standards and best practices including, but not limited to:
+    * Technology Radar
+    * Ways of Working 
+    * Guidelines for DevSecOps policies
+    * Code review
+    
+Tactical responsibilities
+* Guide integration and deployment of DCP components *as a whole*
+* Coordinate emerging tactical request with DCP PM++ that need to be addressed during sprint planning by DCP PM++
+
+### Slack Channels
+
+HumanCellAtlas/tech-architecture: Technical implementation details of DCP components
+and integration between them
+HumanCellAtlas/dcp-integration: Integration *workspace*
+
+## Roles
+
+### Facilitator
+<!-- TBD -->

--- a/charters/Architecture/charter.md
+++ b/charters/Architecture/charter.md
@@ -50,3 +50,7 @@ HumanCellAtlas/dcp-integration: Integration *workspace*
 The DCP Architecture Team Facilitator is a role that rotates among project tech leads.
 
 Current facilitator: [Sam Pierson](mailto:spierson@chanzuckerberg.com)
+
+## Communication
+
+Team email: dcp-architecture-team@data.humancellatlas.org

--- a/charters/Architecture/charter.md
+++ b/charters/Architecture/charter.md
@@ -12,13 +12,14 @@ skills and views needed for community technical decision-making.
 ## In-scope
 
 Software architecture responsibilities
+* Gather and synthesize DCP's end-to-end requirements
 * Set overall direction of architectural and software design direction for the DCP
 * Provide technical input for the PM product roadmap process
 * Review and provide final approval for technical charters for DCP projects
 * Publish Architecture Requests for Comments (RFCs) documenting technical debt that impacts delivery of DCP as an
   integrated system
 * Review and provide final approval for cross-project RFC(s)
-    * Available to mentor on all RFC designs
+    * Available to mentor on all technical RFCs
 * Develop architecture standards and best practices including, but not limited to:
     * Software platforms and frameworks
     * Distributed system design

--- a/charters/Architecture/charter.md
+++ b/charters/Architecture/charter.md
@@ -1,17 +1,17 @@
-# Architecture++
+# DCP Architecture Team
 
 ## Description
 
-Architecture++ is responsible for the technical oversight of the Data Coordination Platform (DCP), including identifying and addressing *cross-cutting* architectural concerns across DCP components.
+The Data Coordination Platform (DCP) Architecture Team is responsible for the technical oversight of the DCP, including identifying and addressing *cross-cutting* architectural concerns across DCP projects.
 
 The core team is composed of *Technical Leads* representing each DCP component to ensure a diversity of skills and views needed for community technical decision-making. 
 
 ## In-scope
 Strategic responsibilities
 * Set overall **technical** direction for the DCP
-* Publish an annual Architecture RFC documenting technical debt that needs to be addressed during roadmap planning by DCP PM++
-* Review and approve technical charters for DCP components
-* Review and approve cross-component RFC(s)
+* Publish Architecture Requests for Comments (RFCs) documenting technical debt that impacts delivery of DCP as an integrated system and must be addressed by PM product plans
+* Review and provide final approval for technical charters for DCP projects
+* Review and provide final approval for cross-component RFC(s)
     * Available to mentor on all RFC designs
 * Develop technical standards and best practices including, but not limited to:
     * Technology Radar
@@ -20,12 +20,12 @@ Strategic responsibilities
     * Code review
     
 Tactical responsibilities
-* Guide integration and deployment of DCP components *as a whole*
-* Coordinate emerging tactical request with DCP PM++ that need to be addressed during sprint planning by DCP PM++
+* Guide integration and deployment of DCP projects *as a whole*
+* Coordinate with DCP PM on emerging tactical requests needing to be addressed in Sprint planning priorities
 
 ### Slack Channels
 
-HumanCellAtlas/tech-architecture: Technical implementation details of DCP components
+HumanCellAtlas/tech-architecture: Technical implementation details of DCP projects
 and integration between them
 HumanCellAtlas/dcp-integration: Integration *workspace*
 

--- a/charters/Architecture/charter.md
+++ b/charters/Architecture/charter.md
@@ -46,4 +46,7 @@ HumanCellAtlas/dcp-integration: Integration *workspace*
 ## Roles
 
 ### Facilitator
-<!-- TBD -->
+
+The DCP Architecture Team Facilitator is a role that rotates among project tech leads.
+
+Current facilitator: [Sam Pierson](mailto:spierson@chanzuckerberg.com)

--- a/charters/Architecture/charter.md
+++ b/charters/Architecture/charter.md
@@ -16,10 +16,10 @@ Software architecture responsibilities
 * Set overall direction of architectural and software design direction for the DCP
 * Provide technical input for the PM product roadmap process
 * Review and provide final approval for technical charters for DCP projects
-* Publish Architecture Requests for Comments (RFCs) documenting technical debt that impacts delivery of DCP as an
-  integrated system
+* Identify risks and tech debt impacting delivery of the DCP roadmap and publish RFCs with strategies to mitigate them
 * Review and provide final approval for cross-project RFC(s)
     * Available to mentor on all technical RFCs
+* Monitor and coordinate with other large open data projects to facilitate data use
 * Develop architecture standards and best practices including, but not limited to:
     * Software platforms and frameworks
     * Distributed system design

--- a/charters/Architecture/charter.md
+++ b/charters/Architecture/charter.md
@@ -2,29 +2,39 @@
 
 ## Description
 
-The Data Coordination Platform (DCP) Architecture Team is responsible for the technical oversight of the DCP,
-including identifying and addressing *cross-cutting* architectural concerns across DCP projects.
+The Data Coordination Platform (DCP) Architecture Team is responsible for the technical oversight of the DCP, including
+identifying and addressing *cross-cutting* architecture, integration, and operational concerns across DCP
+projects.
 
-The core team is composed of *Technical Leads* representing each DCP component to ensure a diversity of skills and
-views needed for community technical decision-making. 
+The core team is composed of *Technical Leads* representing each technical DCP project group to ensure a diversity of
+skills and views needed for community technical decision-making. 
 
 ## In-scope
-Strategic responsibilities
-* Set overall **technical** direction for the DCP
-* Publish Architecture Requests for Comments (RFCs) documenting technical debt that impacts delivery of DCP as an
-  integrated system and must be addressed by PM product plans
+
+Software architecture responsibilities
+* Set overall direction of architectural and software design direction for the DCP
+* Provide technical input for the PM product roadmap process
 * Review and provide final approval for technical charters for DCP projects
-* Review and provide final approval for cross-component RFC(s)
+* Publish Architecture Requests for Comments (RFCs) documenting technical debt that impacts delivery of DCP as an
+  integrated system
+* Review and provide final approval for cross-project RFC(s)
     * Available to mentor on all RFC designs
-* Develop technical standards and best practices including, but not limited to:
-    * Technology Radar
-    * Ways of Working 
-    * Guidelines for DevSecOps policies
-    * Code review
+* Develop architecture standards and best practices including, but not limited to:
+    * Software platforms and frameworks
+    * Distributed system design
     
-Tactical responsibilities
-* Guide integration and deployment of DCP projects *as a whole*
-* Coordinate with DCP PM on emerging tactical requests needing to be addressed in Sprint planning priorities
+Integration and implementation responsibilities
+* Plan and guide integration of DCP projects
+* Coordinate with DCP PM on emerging tactical requests needing to be addressed in sprint planning priorities
+* Develop integration and implementation standards and best practices including, but not limited to:
+    * Software languages frameworks
+    * Code Review
+
+Operational responsibilities
+* Develop Development Operations and Security (DevSecOps) standards and best practices including, but not limited to:
+    * Software tooling
+    * Operational techniques and processes, including software release standard operating procedures
+    * Security policies
 
 ### Slack Channels
 


### PR DESCRIPTION
**Approved at the 10/11/18 DCP PM meeting**

This PR proposes the Architecture++ charter.

Please see charter for more information.