### PR TITLE
RFC Process

### DIFF
--- a/rfcs/rfc-template.md
+++ b/rfcs/rfc-template.md
@@ -6,7 +6,7 @@
 
 # RFC Name
 
-*This is the same as the filename*
+*This is the same as the filename.*
 
 ## Summary
 
@@ -44,7 +44,7 @@
 - *What aspects of the design do you expect to clarify further through the RFC review process?*
 - *What aspects of the design do you expect to clarify later during iterative development of this RFC?*
 
-### Drawbacks / Limitations [optional]
+### Drawbacks and Limitations [optional]
 
 *Why should this RFC **not** be implemented?*
 
@@ -55,5 +55,5 @@
 ### Alternatives [optional]
 
 *Highlight other possible approaches to delivering the value proposed in this RFC. 
-What other designs were explored and what was the rationale for rejecting them?*
+What other designs were explored? What were their advantages? What was the rationale for rejecting alternatives?*
 

--- a/rfcs/rfc-template.md
+++ b/rfcs/rfc-template.md
@@ -27,9 +27,11 @@
 
 ## Motivation
 
-*Describe the user or technical need in detail [with alignment to the DCP **Thematic Roadmap** where possible]. Reference prior community discussions to demonstrate support for this RFC.*
+*Describe the user or technical need in detail [with alignment to the DCP roadmap priorities where possible]. Link prior community discussions to demonstrate support for this RFC.*
 
-### User Stories or Use Cases [optional]
+### User Stories
+
+*Share the [User Stories](https://www.mountaingoatsoftware.com/agile/user-stories) motivating this RFC.*
 
 ## Scientific "guardrails" [optional]
 
@@ -39,7 +41,11 @@
 
 *Explain the design in sufficient detail such that the implementation and (if appropriate) the interaction with existing DCP software are both reasonably clear.*
 
-### Unresolved questions
+### Acceptance Criteria [optional]
+
+*Acceptance criteria are the conditions that a RFC must satisfy to be accepted by users or other stakeholders.* 
+
+### Unresolved Questions
 
 - *What aspects of the design do you expect to clarify further through the RFC review process?*
 - *What aspects of the design do you expect to clarify later during iterative development of this RFC?*
@@ -50,7 +56,7 @@
 
 ### Prior Art [optional]
 
-*Share references to prior art to deepen community understanding of the RFC, such as learnings or adaptations from earlier designs.*
+*Share references to prior art to deepen community understanding of the RFC, such as learnings, adaptations from earlier designs, or community standards.*
 
 ### Alternatives [optional]
 

--- a/rfcs/rfc-template.md
+++ b/rfcs/rfc-template.md
@@ -1,0 +1,59 @@
+### DCP PR:
+
+***Leave this blank until the RFC is approved** then the **Author(s)** must create a link between the assigned RFC number and this pull request in the format:*
+
+`(dcp-community/rfc#)[https://github.com/HumanCellAtlas/dcp-community/pull/<PR#>]`
+
+# RFC Name
+
+*This is the same as the filename*
+
+## Summary
+
+*Describe the vision of the RFC in 2-3 sentences. Consider this section as your "elevator pitch" or "release note" to the community.*
+
+## Author(s)
+
+*Recommended format for Authors:*
+
+ `[Name](mailto:username@example.com)`
+
+## Shepherd
+***Leave this blank.** This role is assigned by DCP PM to guide the **Author(s)** through the RFC process.*
+
+*Recommended format for Shepherds:*
+
+ `[Name](mailto:username@example.com)`
+
+## Motivation
+
+*Describe the user or technical need in detail [with alignment to the DCP **Thematic Roadmap** where possible]. Reference prior community discussions to demonstrate support for this RFC.*
+
+### User Stories or Use Cases [optional]
+
+## Scientific "guardrails" [optional]
+
+*Describe recommended or mandated review from HCA Science governance to ensure that the RFC addresses the needs of the scientific community.*
+
+## Detailed Design
+
+*Explain the design in sufficient detail such that the implementation and (if appropriate) the interaction with existing DCP software are both reasonably clear.*
+
+### Unresolved questions
+
+- *What aspects of the design do you expect to clarify further through the RFC review process?*
+- *What aspects of the design do you expect to clarify later during iterative development of this RFC?*
+
+### Drawbacks / Limitations [optional]
+
+*Why should this RFC **not** be implemented?*
+
+### Prior Art [optional]
+
+*Share references to prior art to deepen community understanding of the RFC, such as learnings or adaptations from earlier designs.*
+
+### Alternatives [optional]
+
+*Highlight other possible approaches to delivering the value proposed in this RFC. 
+What other designs were explored and what was the rationale for rejecting them?*
+

--- a/rfcs/rfc-template.md
+++ b/rfcs/rfc-template.md
@@ -6,7 +6,7 @@
 
 # RFC Name
 
-*This is the same as the filename.*
+*This is the name of the RFC. Keep it short and descriptive.*
 
 ## Summary
 

--- a/rfcs/rfc-template.md
+++ b/rfcs/rfc-template.md
@@ -2,7 +2,7 @@
 
 ***Leave this blank until the RFC is approved** then the **Author(s)** must create a link between the assigned RFC number and this pull request in the format:*
 
-`(dcp-community/rfc#)[https://github.com/HumanCellAtlas/dcp-community/pull/<PR#>]`
+`[dcp-community/rfc#](https://github.com/HumanCellAtlas/dcp-community/pull/<PR#>)`
 
 # RFC Name
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -119,6 +119,8 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 - When all issues are addressed and any required Science reviews are complete, summarize the review discussion for the **Approvers** in a top-level summary comment in the RFC pull request. Replace "rfc-community-review" with "rfc-oversight-review".
 
+  **NOTE**: Oversight review is limited to **Approvers**. Further community reviews during this period may be disregarded by the **Author(s)**.
+
 - For software RFCs, share a link to the RFC pull request for approval on the HumanCellAtlas **#tech-architecture** slack channel. Add the RFC as an agenda item to the next *DCP Architecture* meeting.
 
 - For governance RFCs, share a link to the RFC pull request for approval on the HumanCellAtlas **#dcp-project-mgmt** slack channel. Add the RFC as an agenda item to the next *DCP PM* meeting.

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-The Human Cell Atlas Data Coordination Platform (HCA DCP) evolved informal, consensus-driven processes to coordinate and document technical decisions.
+The Human Cell Atlas Data Coordination Platform (HCA DCP) evolved informal, consensus-driven processes to coordinate and document technical and governance decisions.
 
 This early *lightweight* and *egalitarian* approach enabled the DCP to achieve rapid velocity and incorporate a diverse set of innovative design concepts.
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -89,11 +89,31 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
         
       - Add the "rfc-community-review" and the "Governance" labels. 
 
-  - Share a link to the RFC pull request for community review on the HumanCellAtlas **#dcp** slack channel
+- Add a minimum two week _last call_ for the completion of the Community review to the top-level summary comment in the RFC pull request.
+
+    **EXAMPLE**: 
+
+    **April 1**: Last call for community review
+
+- Request a Community review of the RFC on the HumanCellAtlas **#dcp** slack channel. Include a link to the RFC pull request and the last call deadline:
+
+    **EXAMPLE** 
+  
+     ***@channel**: Call for community review of the RFC process - https://github.com/HumanCellAtlas/dcp-community/pull/27 - Last call is April 1.*
 
 #### DCP PM:
 - Assign a **Shepherd** by completing the *Shepherd* section in the RFC template and pushing the commit. The **Shepherd** guides the RFC and its **Author(s)** through the process.
-- If there is a *Scientific "guardrails"* section in the RFC, assign the **Science Reviewer** as a reviewer of the pull request and add the "science-review-required" label.
+
+- If there is a *Scientific "guardrails"* section in the RFC:
+  - Assign the **Science Reviewer** as a reviewer of the pull request
+  - Add the "science-review-required" label
+  - Add a two week _last call_ for the completion of the Science review to the top-level summary comment in the RFC pull request.
+
+    **EXAMPLE**: 
+
+    **April 5**: Last call for science review
+
+   **NOTE**: The Science review occurs in parallel to the Community review. 
 
 ### Reviewing RFCs
 
@@ -114,13 +134,30 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 #### Shepherd:
 - Monitor the community review and ensure that issues are addressed by the **Author(s)** in a reasonable time period.
 
-- When all issues are addressed and any required Science reviews are complete, summarize the review discussion for the **Approvers** in a top-level summary comment in the RFC pull request. Replace "rfc-community-review" with "rfc-oversight-review".
+- When all issues are addressed and any required Science reviews are complete:
+  - Summarize the review discussion for the **Approvers** in the top-level summary comment in the RFC pull request
+  - Add a minimum one week _last call_ for the completion of the Oversight review to the top-level summary comment in the RFC pull request.
+
+    **EXAMPLE**: 
+
+    ~~**April 1**: Last call for community review~~
+    **April 22**: Last call for oversight review
+
+  - Replace "rfc-community-review" with "rfc-oversight-review"
 
   **NOTE**: Oversight review is limited to **Approvers**. Further community reviews during this period may be disregarded by the **Author(s)**.
 
-- For software RFCs, share a link to the RFC pull request for approval on the HumanCellAtlas **#tech-architecture** slack channel. Add the RFC as an agenda item to the next *DCP Architecture* meeting.
+- For software RFCs, request an Oversight review of the RFC on the HumanCellAtlas **#tech-architecture** slack channel. Include a link to the RFC pull request and the last call deadline:
 
-- For governance RFCs, share a link to the RFC pull request for approval on the HumanCellAtlas **#dcp-project-mgmt** slack channel. Add the RFC as an agenda item to the next *DCP PM* meeting.
+    **EXAMPLE** 
+  
+     ***@channel**: Call for oversight review of the RFC process - https://github.com/HumanCellAtlas/dcp-community/pull/27 - Last call is April 22.*
+
+  Add the RFC as an agenda item to the next *DCP Architecture* meeting
+
+- For governance RFCs, request an Oversight review of the RFC on the HumanCellAtlas **#dcp-project-mgmt** slack channel. Include a link to the RFC pull request and the last call deadline
+
+  Add the RFC as an agenda item to the next *DCP PM* meeting
 
 ### Approving RFCs
 
@@ -145,7 +182,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 #### Shepherd:
 
-- If substantial changes are requested during the oversight review, then replace "rfc-oversight-review" with "rfc-community-review" and return to the [community review](#shepherding-rfcs) process.
+- If substantial changes are requested during the Oversight review, then replace "rfc-oversight-review" with "rfc-community-review" and return to the [community review](#shepherding-rfcs) process.
 
 ### Rejecting RFCs
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -28,7 +28,7 @@ There are a number of limitations with our current process which need to be addr
 
   - There is no common process describing how the community reviews and approves submitted proposals.
 
-  - There is no formal assistance to guide a contributor through the RFC process. 
+  - There is no formal assistance to guide a contributor through the process. 
 
 - New community members experience difficulties when _onboarding_. There is no curated repository of up-to-date design documents to assist with learning about the software. 
 
@@ -36,30 +36,30 @@ There are a number of limitations with our current process which need to be addr
 
 To address these needs, the DCP RFC process defines a transparent and standard method for community members to propose and build consensus around substantial enhancements to DCP software or governance.
 
-### When is a RFC required?
+### When is an RFC required?
 
-Any proposal that would benefit from additional review or design before being implemented is a good candidate for a RFC.
+Any proposal that would benefit from additional review or design before being implemented is a good candidate for an RFC.
 
-- A RFC is required if the implemented design would be described in written communication to the community.
-- A RFC is required if a design impacts the scope of multiple projects.
-- A RFC is required if a technical initiative (refactoring, major architectural change) impacts the community.
-- A RFC is required for all changes to DCP governance.  
+- An RFC is required if the implemented design would be described in written communication to the community.
+- An RFC is required if a design impacts the scope of multiple projects.
+- An RFC is required if a technical initiative (refactoring, major architectural change) impacts the community.
+- An RFC is required for all changes to DCP governance.  
 
-### Revising RFC(s)
+### Revising RFCs
 
-How are RFC(s) maintained as *living documents* in an iterative development process where the original design may substantially change based on implementation experiences?
+How are RFCs maintained as *living documents* in an iterative development process where the original design may substantially change based on implementation experiences?
 
-Where necessary, existing RFCs can be revised using the same process (a proposed change submitted as a pull request and subject to community review and approval). **Major changes should result in a new RFC.**
+Where necessary, existing RFCs can be revised using the same process (a proposed change submitted as a RFC pull request and subject to community review and approval). **Major changes should result in a new RFC.**
 
 ### What are the roles in the RFC process?
 
 - **Authors** are DCP community members.
 
-- **Shepherds** are members of *DCP PM* assigned to assist the **Author(s)** and ensure that a RFC progresses to closure.
+- **Shepherds** are members of *DCP PM* assigned to assist the **Author(s)** and ensure that the RFC progresses to closure.
 
-- **Approvers** for governance RFC(s) are the Project Leads and Product Owners from *DCP PM*.
+- **Approvers** for governance RFCs are the Project Leads and Product Owners from *DCP PM*.
 
-- **Approvers** for software RFC(s) are the Technical Leads from *DCP Architecture*. 
+- **Approvers** for software RFCs are the Technical Leads from *DCP Architecture*. 
 
 - **Reviewers** are DCP community members.
 
@@ -67,7 +67,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 ## Detailed Design
 
-### Proposing RFC(s)
+### Proposing RFCs
 
 #### **Authors**:
 
@@ -75,20 +75,20 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
   - Fork the HumanCellAtlas dcp-community repository
   - Copy `rfcs/rfc-template.md` to `rfcs/text/0000-my-feature.md`
-  *- where "my-feature" is descriptive. Don't assign a RFC number yet.*
+  *- where "my-feature" is descriptive. Don't assign an RFC number yet.*
   
   - Fill in the RFC with attention to detail
 
   - Submit a pull request.
   
-      For software RFC(s):
+      For software RFCs:
       - Add the "rfc-proposed" and the appropriate software project name _(such as "Data Store")_ labels. When the RFC crosses the scope of software projects, then the "Architecture" label **MUST** be the project name. *If uncertain about the appropriate project name, then **_Ask a PM_** on the HCA **#dcp-project-mgmt** slack channel*
 
       For governance RFCs:
         
       - Add the "rfc-proposed" and the "Governance" labels. 
 
-  - Share a link to the pull request for community review on the HumanCellAtlas **#dcp** slack channel
+  - Share a link to the RFC pull request for community review on the HumanCellAtlas **#dcp** slack channel
 
 #### DCP PM:
 - Assign a **Shepherd** by completing the *Shepherd* section in the RFC template and pushing the update. The **Shepherd** guides the RFC and its **Author(s)** through the process.
@@ -97,34 +97,34 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 #### Shepherd:
 - Include the RFC submission in *This week in DCP* status update
 
-### Reviewing RFC(s)
+### Reviewing RFCs
 
 #### Approvers:
 - May assign specific reviewers in the RFC pull request
 
 #### Reviewers:
-- Add feedback to the pull request comment thread
+- Add feedback to the RFC pull request comment thread
 
 #### Science Reviewer:
 - When the feedback from the Science review is addressed, replace the "science-review-required" label with "science-review-completed".
 
 #### Author: 
-- Revise the pull request in response to feedback and push new commits
+- Revise the RFC pull request in response to feedback and push new commits
 
-### Shepherding RFC(s)
+### Shepherding RFCs
 
 #### Shepherd:
 - Monitor the community review and ensure that issues are addressed by the **Author(s)** in a reasonable time period.
 
-- When all issues are addressed and any required Science reviews are complete, summarize the review discussion for the **Approvers** in a top-level summary comment in the pull request. Replace "rfc-proposed" with "rfc-final-review".
+- When all issues are addressed and any required Science reviews are complete, summarize the review discussion for the **Approvers** in a top-level summary comment in the RFC pull request. Replace "rfc-proposed" with "rfc-final-review".
 
-- For software RFC(s), share a link to the pull request for approval on the HumanCellAtlas **#tech-architecture** slack channel. Add the RFC as an agenda item to the next *DCP Architecture* meeting.
+- For software RFCs, share a link to the RFC pull request for approval on the HumanCellAtlas **#tech-architecture** slack channel. Add the RFC as an agenda item to the next *DCP Architecture* meeting.
 
-- For governance RFC(s), share a link to the pull request for approval on the HumanCellAtlas **#dcp-project-mgmt** slack channel. Add the RFC as an agenda item to the next *DCP PM* meeting.
+- For governance RFCs, share a link to the RFC pull request for approval on the HumanCellAtlas **#dcp-project-mgmt** slack channel. Add the RFC as an agenda item to the next *DCP PM* meeting.
 
 - Include the RFC final review in *This week in DCP* status update
 
-### Approving RFC(s)
+### Approving RFCs
 
 #### Approvers:
 
@@ -135,7 +135,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 - Create a link between the approved RFC and its pull request by updating the *DCP PR* section in the RFC template and pushing the update.
 
-- Merge RFC pull request
+- Merge the RFC pull request
 
 **NOTE**: *The existence of an approved software RFC does not indicate any particular priority or commitment to implement the RFC, nor is an approved RFC a green light to implement. Approved RFCs simply demonstrate community agreement on a technical decision. Product priorities are managed and implementations scheduled via the DCP PM planning process.*
 
@@ -144,7 +144,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 - Validate that the RFC pull request was successfully updated and merged
 - Include the RFC approval in *This week in DCP* status update
 
-### Rejecting RFC(s)
+### Rejecting RFCs
 
 #### Approvers:
 
@@ -154,7 +154,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 - Include the RFC rejection in *This week in DCP* status update
 
 #### Author:
-- If a RFC is rejected by *DCP Architecture*, then the decision may be escalated for review by *DCP PM* by sending a request to the HumanCellAtlas **#dcp-project-mgmt** slack channel
+- If an RFC is rejected by *DCP Architecture*, then the decision may be escalated for review by *DCP PM* by sending a request to the HumanCellAtlas **#dcp-project-mgmt** slack channel
 
 ### Unresolved questions
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -4,16 +4,16 @@
 
 ## Summary
 
-The Human Cell Atlas Data Coordination Platform (HCA DCP) evolved informal, consensus-driven processes to coordinate and document technical and governance decisions.
+The Human Cell Atlas Data Coordination Platform (HCA DCP) evolved informal processes to coordinate and document technical and governance decisions.
 
-This early *lightweight* and *egalitarian* approach enabled the DCP to achieve rapid velocity and incorporate a diverse set of innovative design concepts.
+This early *lightweight* approach enabled the DCP to achieve rapid velocity and incorporate a diverse set of innovative design concepts.
 
-As DCP continues to mature and scale, our community can more easily contribute and learn when there is a formal and consistent **Request for Comments (RFC)** process to propose enhancements to software or governance which are then maintained in a central repository.
+As DCP continues to mature and scale, our community can more easily contribute and learn when there is a formal and consensus-driven **Request for Comments (RFC)** process to propose enhancements to software or governance which are then maintained in a central repository.
 
 ## Author(s)
 *DCP PM*
 
-**Note:** *This proposal is based on ideas from the **HCA DCP Technical Decision-Making** white paper written by Bruce Martin with contributions from Tony Burdett, Laura Clarke, Brian O’Connor, Brian Raymor, and Tim Tickle.*
+**NOTE:** *This proposal is based on ideas from the **HCA DCP Technical Decision-Making** white paper written by Bruce Martin with contributions from Tony Burdett, Laura Clarke, Brian O’Connor, Brian Raymor, and Tim Tickle.*
 
 ## Shepherd
 [Brian Raymor](brianraymor@chanzuckerberg.com)
@@ -32,18 +32,21 @@ There are a number of limitations with our current process which need to be addr
 
 - New community members experience difficulties when _onboarding_. There is no curated repository of up-to-date design documents to assist with learning about the software. 
 
-- To ensure consistency of the architectural design, senior technical leaders must monitor multiple work streams or hope that they are notified of potential technical changes - *this is a significant concern for cross-cutting issues such as security or the data model*.
+- Members cannot easily follow the decision making process for major features.
+
+  To ensure consistency of the architectural design, senior technical leaders must monitor multiple work streams which is time consuming, or hope that they are notified of potential technical changes - *this is a significant concern for cross-cutting issues such as security or the data model*.
 
 To address these needs, the DCP RFC process defines a transparent and standard method for community members to propose and build consensus around substantial enhancements to DCP software or governance.
 
 ### When is an RFC required?
 
-Any proposal that would benefit from additional review or design before being implemented is a good candidate for an RFC.
+- An RFC is required for **substantial** additions, deletions, or changes to system behavior or semantics (API, major features, data model, protocols,​ ​service guarantees, architecture). In [semver](https://semver.org/) terms, *major* changes require an RFC, while *minor* changes are often candidates (new API addition).
 
-- An RFC is required if the implemented design would be described in written communication to the community.
+    **NOTE**: *Internal-only implementation decisions, bug fixes, refactoring, and performance optimization are not substantial changes and can continue to be documented and tracked using github issues.*
+
 - An RFC is required if a design impacts multiple DCP projects.
-- An RFC is required if a technical initiative (refactoring, major architectural change) impacts the community.
-- A RFC is required for all changes to the DCP formal governance, including but not limited to oversight, decision-making, conflict resolution, and community processes such as charters and RFCs. For more background on governance, see the **Model C: Delegated Governance** section in [Organization & Structure of Open Source Software Development Initiatives](https://dash.harvard.edu/bitstream/handle/1/30805146/2017-03-24_governance.pdf).  
+
+- An RFC is required for all changes to the DCP formal governance, including but not limited to oversight, decision-making, conflict resolution, and community processes such as charters and RFCs. For more background on governance, see the **Model C: Delegated Governance** section in [Organization & Structure of Open Source Software Development Initiatives](https://dash.harvard.edu/bitstream/handle/1/30805146/2017-03-24_governance.pdf).  
 
 ### Revising RFCs
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -95,9 +95,6 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 - Assign a **Shepherd** by completing the *Shepherd* section in the RFC template and pushing the commit. The **Shepherd** guides the RFC and its **Author(s)** through the process.
 - If there is a *Scientific "guardrails"* section in the RFC, assign the **Science Reviewer** as a reviewer of the pull request and add the "science-review-required" label.
 
-#### Shepherd:
-- Include the RFC submission in *This week in DCP* status update
-
 ### Reviewing RFCs
 
 #### Approvers:
@@ -125,8 +122,6 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 - For governance RFCs, share a link to the RFC pull request for approval on the HumanCellAtlas **#dcp-project-mgmt** slack channel. Add the RFC as an agenda item to the next *DCP PM* meeting.
 
-- Include the RFC final review in *This week in DCP* status update
-
 ### Approving RFCs
 
 #### Approvers:
@@ -145,7 +140,6 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 #### Shepherd:
 
 - Validate that the RFC pull request was successfully updated and merged
-- Include the RFC approval in *This week in DCP* status update
 
 ### Requesting substantive changes
 
@@ -158,9 +152,6 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 #### Approvers:
 
 - At the *DCP PM* or *DCP Architecture* meeting, review the **Shepherd** summary. If there is rough consensus to reject the RFC, replace "rfc-oversight-review" with "rfc-declined", and close the pull request with the rationale in the comment.
-
-#### Shepherd:
-- Include the RFC rejection in *This week in DCP* status update
 
 #### Author:
 - If an RFC is rejected by *DCP Architecture*, then the decision may be escalated for review by *DCP PM* by sending a request to the HumanCellAtlas **#dcp-project-mgmt** slack channel

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -113,7 +113,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 - Revise the RFC pull request in response to feedback and push new commits
 
 ### Shepherding RFCs
-
+[Shepherding RFCs]: #shepherding-rfcs
 #### Shepherd:
 - Monitor the community review and ensure that issues are addressed by the **Author(s)** in a reasonable time period.
 
@@ -146,6 +146,12 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 - Validate that the RFC pull request was successfully updated and merged
 - Include the RFC approval in *This week in DCP* status update
+
+### Requesting substantive changes
+
+#### Shepherd:
+
+- If substantial changes are requested during the oversight review, then replace "rfc-oversight-review" with "rfc-community-review" and return to the [community review](#shepherding-rfcs) process.
 
 ### Rejecting RFCs
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -181,9 +181,9 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 - Announce the approval of the RFC on the HumanCellAtlas #dcp slack channel. Include a link to the merged RFC:
 
-  EXAMPLE
+  **EXAMPLE**
 
-  @channel: *DCP PM* approved the RFC for the RFC Process - https://github.com/HumanCellAtlas/dcp-community/rfcs/blob/master/text/0001-rfc-process.md
+  ***@channel**: DCP PM approved the RFC for the RFC Process - https://github.com/HumanCellAtlas/dcp-community/rfcs/blob/master/text/0001-rfc-process.md*
 
 ### Requesting substantive changes
 
@@ -205,9 +205,9 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 - Announce the rejection of the RFC on the HumanCellAtlas #dcp slack channel. Include a link to the RFC pull request:
 
-  EXAMPLE
+  **EXAMPLE**
 
-  @channel: *DCP PM* declined the RFC for the RFC Process - https://github.com/HumanCellAtlas/dcp-community/pull/27
+  ***@channel**: DCP PM declined the RFC for the RFC Process - https://github.com/HumanCellAtlas/dcp-community/pull/27*
 
 ### Appealing RFC Decisions
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -183,7 +183,11 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 #### Approvers:
 
-- At the *DCP PM* or *DCP Architecture* meeting, review the **Shepherd** summary. If substantial changes are requested, then replace "rfc-oversight-review" with "rfc-community-review" and return the RFC to the [community review](#shepherding-rfcs) process.
+- At the *DCP PM* or *DCP Architecture* meeting, review the **Shepherd** summary. If substantial changes are requested, then replace "rfc-oversight-review" with "rfc-community-review".
+
+#### Authors:
+
+- The **Author(s)** must address the changes before requesting a community review and returning the RFC to the [community review](#shepherding-rfcs) process.
 
 ### Rejecting RFCs
 
@@ -193,7 +197,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 ### Appealing RFC Decisions
 
-Any DCP community member may appeal an RFC decision (approval or rejection) by sending a message to the *DCP PM* mailing list (pm-team@data.humancellatlas.org).
+Any DCP community member may appeal all RFC decisions by **Approvers** (approval, changes requested, or rejection) by sending a message to the *DCP PM* mailing list (pm-team@data.humancellatlas.org).
 
 The message should demonstrate a clear rationale for the appeal, referencing community discussion as needed to support the position.
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -201,9 +201,11 @@ The message should demonstrate a clear rationale for the appeal, referencing com
 
 ### Unresolved questions
 
-*What aspects of the design do you expect to clarify further through the RFC review process?*
+*What aspects of the design do you expect to clarify later during iterative development of this RFC?*
 
-There is a [pending issue](https://github.com/HumanCellAtlas/dcp-community/issues/25) to define how DCP might document when an approved RFC is implemented.
+- [Adding Informational RFCs](https://github.com/HumanCellAtlas/dcp-community/issues/30)
+- [Tracking the implementation state of approved RFCs](https://github.com/HumanCellAtlas/dcp-community/issues/25)
+- [Improving community notifications for RFCs](https://github.com/HumanCellAtlas/dcp-community/issues/37)
 
 ### Drawbacks / Limitations
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -43,7 +43,7 @@ Any proposal that would benefit from additional review or design before being im
 - An RFC is required if the implemented design would be described in written communication to the community.
 - An RFC is required if a design impacts multiple DCP projects.
 - An RFC is required if a technical initiative (refactoring, major architectural change) impacts the community.
-- An RFC is required for all changes to DCP governance.  
+- A RFC is required for all changes to the DCP formal governance, including but not limited to oversight, decision-making, conflict resolution, and community processes such as charters and RFCs. For more background on governance, see the **Model C: Delegated Governance** section in [Organization & Structure of Open Source Software Development Initiatives](https://dash.harvard.edu/bitstream/handle/1/30805146/2017-03-24_governance.pdf).  
 
 ### Revising RFCs
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -179,6 +179,12 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 - Validate that the RFC pull request was successfully updated and merged
 
+- Announce the approval of the RFC on the HumanCellAtlas #dcp slack channel. Include a link to the merged RFC:
+
+  EXAMPLE
+
+  @channel: *DCP PM* approved the RFC for the RFC Process - https://github.com/HumanCellAtlas/dcp-community/rfcs/blob/master/text/0001-rfc-process.md
+
 ### Requesting substantive changes
 
 #### Approvers:
@@ -194,6 +200,14 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 #### Approvers:
 
 - At the *DCP PM* or *DCP Architecture* meeting, review the **Shepherd** summary. If there is rough consensus to reject the RFC, replace "rfc-oversight-review" with "rfc-declined", and close the pull request with the rationale in the comment.
+
+#### Shepherd:
+
+- Announce the rejection of the RFC on the HumanCellAtlas #dcp slack channel. Include a link to the RFC pull request:
+
+  EXAMPLE
+
+  @channel: *DCP PM* declined the RFC for the RFC Process - https://github.com/HumanCellAtlas/dcp-community/pull/27
 
 ### Appealing RFC Decisions
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -1,0 +1,174 @@
+### DCP PR:
+
+# RFC Process
+
+## Summary
+
+The Human Cell Atlas Data Coordination Platform (HCA DCP) evolved informal, consensus-driven processes to coordinate and document technical decisions.
+
+This early *lightweight* and *egalitarian* approach enabled the DCP to achieve rapid velocity and incorporate a diverse set of innovative design concepts.
+
+As DCP continues to mature and scale, our community can more easily contribute and learn when there is a formal and consistent **Request for Comments (RFC)** process to propose enhancements to software or governance which are then maintained in a central repository.
+
+## Author(s)
+*DCP PM*
+
+**Note:** *This proposal is based on ideas from the **HCA DCP Technical Decision-Making** white paper written by Bruce Martin with contributions from Tony Burdett, Laura Clarke, Brian O’Connor, Brian Raymor, and Tim Tickle.*
+
+## Shepherd
+[Brian Raymor](brianraymor@chanzuckerberg.com)
+
+## Motivation
+
+There are a number of limitations with our current process which need to be addressed:
+
+- For community members who want to propose enhancements to either technical software or governance, it is often unclear where to start - *for example, which HCA slack channel or project member to approach with a proposal.*
+
+  - There is no common template for design proposal submissions.
+
+  - There is no common process describing how the community reviews and approves submitted proposals.
+
+  - There is no formal assistance to guide a contributor through the RFC process. 
+
+- New community members experience difficulties when _onboarding_. There is no curated repository of up-to-date design documents to assist with learning about the software. 
+
+- To ensure consistency of the architectural design, senior technical leaders must monitor multiple work streams or hope that they are notified of potential technical changes - *this is a significant concern for cross-cutting issues such as security or the data model*.
+
+To address these needs, the DCP RFC process defines a transparent and standard method for community members to propose and build consensus around substantial enhancements to DCP software or governance.
+
+### When is a RFC required?
+
+Any proposal that would benefit from additional review or design before being implemented is a good candidate for a RFC.
+
+- A RFC is required if the implemented design would be described in written communication to the community.
+- A RFC is required if a design impacts the scope of multiple projects.
+- A RFC is required if a technical initiative (refactoring, major architectural change) impacts the community.
+- A RFC is required for all changes to DCP governance.  
+
+### Revising RFC(s)
+
+How are RFC(s) maintained as *living documents* in an iterative development process where the original design may substantially change based on implementation experiences?
+
+Where necessary, existing RFCs can be revised using the same process (a proposed change submitted as a pull request and subject to community review and approval). **Major changes should result in a new RFC.**
+
+### What are the roles in the RFC process?
+
+- **Authors** are DCP community members.
+
+- **Shepherds** are members of *DCP PM* assigned to assist the **Author(s)** and ensure that a RFC progresses to closure.
+
+- **Approvers** for governance RFC(s) are the Project Leads and Product Owners from *DCP PM*.
+
+- **Approvers** for software RFC(s) are the Technical Leads from *DCP Architecture*. 
+
+- **Reviewers** are DCP community members.
+
+- **Science Reviewer** is the *DCP Science PM* in coordination with *HCA Science Governance*.
+
+## Detailed Design
+
+### Proposing RFC(s)
+
+#### **Authors**:
+
+*Before proposing, always engage the DCP community to build consensus and assess whether your proposal sparks interest and addresses a need. You may even discover potential collaborators.*
+
+  - Fork the HumanCellAtlas dcp-community repository
+  - Copy `rfcs/rfc-template.md` to `rfcs/text/0000-my-feature.md`
+  *- where "my-feature" is descriptive. Don't assign a RFC number yet.*
+  
+  - Fill in the RFC with attention to detail
+
+  - Submit a pull request.
+  
+      For software RFC(s):
+      - Add the "rfc-proposed" and the appropriate software project name _(such as "Data Store")_ labels. When the RFC crosses the scope of software projects, then the "Architecture" label **MUST** be the project name. *If uncertain about the appropriate project name, then **_Ask a PM_** on the HCA **#dcp-project-mgmt** slack channel*
+
+      For governance RFCs:
+        
+      - Add the "rfc-proposed" and the "Governance" labels. 
+
+  - Share a link to the pull request for community review on the HumanCellAtlas **#dcp** slack channel
+
+#### DCP PM:
+- Assign a **Shepherd** by completing the *Shepherd* section in the RFC template and pushing the update. The **Shepherd** guides the RFC and its **Author(s)** through the process.
+- If there is a *Scientific "guardrails"* section in the RFC, assign the **Science Reviewer** as a reviewer of the pull request and add the "science-review-required" label.
+
+#### Shepherd:
+- Include the RFC submission in *This week in DCP* status update
+
+### Reviewing RFC(s)
+
+#### Approvers:
+- May assign specific reviewers in the RFC pull request
+
+#### Reviewers:
+- Add feedback to the pull request comment thread
+
+#### Science Reviewer:
+- When the feedback from the Science review is addressed, replace the "science-review-required" label with "science-review-completed".
+
+#### Author: 
+- Revise the pull request in response to feedback and push new commits
+
+### Shepherding RFC(s)
+
+#### Shepherd:
+- Monitor the community review and ensure that issues are addressed by the **Author(s)** in a reasonable time period.
+
+- When all issues are addressed and any required Science reviews are complete, summarize the review discussion for the **Approvers** in a top-level summary comment in the pull request. Replace "rfc-proposed" with "rfc-final-review".
+
+- For software RFC(s), share a link to the pull request for approval on the HumanCellAtlas **#tech-architecture** slack channel. Add the RFC as an agenda item to the next *DCP Architecture* meeting.
+
+- For governance RFC(s), share a link to the pull request for approval on the HumanCellAtlas **#dcp-project-mgmt** slack channel. Add the RFC as an agenda item to the next *DCP PM* meeting.
+
+- Include the RFC final review in *This week in DCP* status update
+
+### Approving RFC(s)
+
+#### Approvers:
+
+- At the *DCP PM* or *DCP Architecture* meeting, review the **Shepherd** summary. If there is rough consensus to approve the RFC, replace "rfc-final-review" with "rfc-approved"
+
+#### Author(s):
+- Rename the RFC from `0000-my-feature.md` to `rfc####-my-feature.md` (with leading zeros) where `####` is the next available RFC number
+
+- Create a link between the approved RFC and its pull request by updating the *DCP PR* section in the RFC template and pushing the update.
+
+- Merge RFC pull request
+
+**NOTE**: *The existence of an approved software RFC does not indicate any particular priority or commitment to implement the RFC, nor is an approved RFC a green light to implement. Approved RFCs simply demonstrate community agreement on a technical decision. Product priorities are managed and implementations scheduled via the DCP PM planning process.*
+
+#### Shepherd:
+
+- Validate that the RFC pull request was successfully updated and merged
+- Include the RFC approval in *This week in DCP* status update
+
+### Rejecting RFC(s)
+
+#### Approvers:
+
+- At the *DCP PM* or *DCP Architecture* meeting, review the **Shepherd** summary. If there is rough consensus to reject the RFC, replace "rfc-final-review" with "rfc-declined", and close the pull request with the rationale in the comment.
+
+#### Shepherd:
+- Include the RFC rejection in *This week in DCP* status update
+
+#### Author:
+- If a RFC is rejected by *DCP Architecture*, then the decision may be escalated for review by *DCP PM* by sending a request to the HumanCellAtlas **#dcp-project-mgmt** slack channel
+
+### Unresolved questions
+
+*What aspects of the design do you expect to clarify further through the RFC review process?*
+
+There is a [pending issue](https://github.com/HumanCellAtlas/dcp-community/issues/25) to define how DCP might document when an approved RFC is implemented.
+
+### Drawbacks / Limitations
+
+The dependence on Git and GitHub in the RFC process may be a barrier to potential contributors, but this is mitigated by the availability of the **Shepherd**. 
+
+## Prior Art
+
+The DCP RFC process is _inspired_ by and _adapted_ from [Rust](https://github.com/rust-lang/rfcs)
+and [Kubernetes](https://kubernetes.io/docs/community/keps/).
+
+The Internet Engineering Task Force assigns a [**Shepherd**](https://tools.ietf.org/html/rfc4858#section-3.1) during the _endgame_ of their standards process. 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -91,7 +91,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 - Add a minimum two week _last call_ for the completion of the Community review to the top-level summary comment in the RFC pull request.
 
-    **EXAMPLE**: 
+    **EXAMPLE** 
 
     **April 1**: Last call for community review
 
@@ -109,11 +109,11 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
   - Add the "science-review-required" label
   - Add a two week _last call_ for the completion of the Science review to the top-level summary comment in the RFC pull request.
 
-    **EXAMPLE**: 
+    **EXAMPLE** 
 
     **April 5**: Last call for science review
 
-   **NOTE**: The Science review occurs in parallel to the Community review. 
+   **NOTE**: *The Science review occurs in parallel to the Community review.* 
 
 ### Reviewing RFCs
 
@@ -138,24 +138,25 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
   - Summarize the review discussion for the **Approvers** in the top-level summary comment in the RFC pull request
   - Add a minimum one week _last call_ for the completion of the Oversight review to the top-level summary comment in the RFC pull request.
 
-    **EXAMPLE**: 
+    **EXAMPLE** 
 
     ~~**April 1**: Last call for community review~~
+
     **April 22**: Last call for oversight review
 
   - Replace "rfc-community-review" with "rfc-oversight-review"
 
-  **NOTE**: Oversight review is limited to **Approvers**. Further community reviews during this period may be disregarded by the **Author(s)**.
+  **NOTE**: *Oversight review is limited to **Approvers**. Further community reviews during this period may be disregarded by the **Author(s)**.*
 
-- For software RFCs, request an Oversight review of the RFC on the HumanCellAtlas **#tech-architecture** slack channel. Include a link to the RFC pull request and the last call deadline:
+- For software RFCs, request an Oversight review of the RFC on the HumanCellAtlas **#tech-architecture** slack channel. Include a link to the RFC pull request and the last call deadline
+
+  Add the RFC as an agenda item to the next *DCP Architecture* meeting
+
+- For governance RFCs, request an Oversight review of the RFC on the HumanCellAtlas **#dcp-project-mgmt** slack channel. Include a link to the RFC pull request and the last call deadline:
 
     **EXAMPLE** 
   
      ***@channel**: Call for oversight review of the RFC process - https://github.com/HumanCellAtlas/dcp-community/pull/27 - Last call is April 22.*
-
-  Add the RFC as an agenda item to the next *DCP Architecture* meeting
-
-- For governance RFCs, request an Oversight review of the RFC on the HumanCellAtlas **#dcp-project-mgmt** slack channel. Include a link to the RFC pull request and the last call deadline
 
   Add the RFC as an agenda item to the next *DCP PM* meeting
 
@@ -180,9 +181,9 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 ### Requesting substantive changes
 
-#### Shepherd:
+#### Approvers:
 
-- If substantial changes are requested during the Oversight review, then replace "rfc-oversight-review" with "rfc-community-review" and return to the [community review](#shepherding-rfcs) process.
+- At the *DCP PM* or *DCP Architecture* meeting, review the **Shepherd** summary. If substantial changes are requested, then replace "rfc-oversight-review" with "rfc-community-review" and return the RFC to the [community review](#shepherding-rfcs) process.
 
 ### Rejecting RFCs
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -190,8 +190,13 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 - At the *DCP PM* or *DCP Architecture* meeting, review the **Shepherd** summary. If there is rough consensus to reject the RFC, replace "rfc-oversight-review" with "rfc-declined", and close the pull request with the rationale in the comment.
 
-#### Author:
-- If an RFC is rejected by *DCP Architecture*, then the decision may be escalated for review by *DCP PM* by sending a request to the HumanCellAtlas **#dcp-project-mgmt** slack channel
+### Appealing RFC Decisions
+
+Any DCP community member may appeal an RFC decision (approval or rejection) by sending a message to the *DCP PM* mailing list (pm-team@data.humancellatlas.org).
+
+The message should demonstrate a clear rationale for the appeal, referencing community discussion as needed to support the position.
+
+*DCP PM* must review the appeal, resolve it in a manner of its own choosing, and respond to the original message on the *DCP PM* mailing list within two weeks.
 
 ### Unresolved questions
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -41,13 +41,11 @@ To address these needs, the DCP RFC process defines a transparent and standard m
 Any proposal that would benefit from additional review or design before being implemented is a good candidate for an RFC.
 
 - An RFC is required if the implemented design would be described in written communication to the community.
-- An RFC is required if a design impacts the scope of multiple projects.
+- An RFC is required if a design impacts multiple DCP projects.
 - An RFC is required if a technical initiative (refactoring, major architectural change) impacts the community.
 - An RFC is required for all changes to DCP governance.  
 
 ### Revising RFCs
-
-How are RFCs maintained as *living documents* in an iterative development process where the original design may substantially change based on implementation experiences?
 
 Where necessary, existing RFCs can be revised using the same process (a proposed change submitted as a RFC pull request and subject to community review and approval). **Major changes should result in a new RFC.**
 
@@ -61,7 +59,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 - **Approvers** for software RFCs are the Technical Leads from *DCP Architecture*. 
 
-- **Reviewers** are DCP community members.
+- **Reviewers** are DCP community members, including both software developers and users.
 
 - **Science Reviewer** is the *DCP Science PM* in coordination with *HCA Science Governance*.
 
@@ -82,7 +80,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
   - Submit a pull request.
   
       For software RFCs:
-      - Add the "rfc-proposed" and the appropriate software project name _(such as "Data Store")_ labels. When the RFC crosses the scope of software projects, then the "Architecture" label **MUST** be the project name. *If uncertain about the appropriate project name, then **_Ask a PM_** on the HCA **#dcp-project-mgmt** slack channel*
+      - Add the "rfc-proposed" and the appropriate software project name _(such as "Data Store")_ labels. When the RFC impacts multiple DCP software projects, then the "Architecture" label **MUST** be the project name. *If uncertain about the appropriate project name, then **_Ask a PM_** on the HCA **#dcp-project-mgmt** slack channel*
 
       For governance RFCs:
         
@@ -91,7 +89,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
   - Share a link to the RFC pull request for community review on the HumanCellAtlas **#dcp** slack channel
 
 #### DCP PM:
-- Assign a **Shepherd** by completing the *Shepherd* section in the RFC template and pushing the update. The **Shepherd** guides the RFC and its **Author(s)** through the process.
+- Assign a **Shepherd** by completing the *Shepherd* section in the RFC template and pushing the commit. The **Shepherd** guides the RFC and its **Author(s)** through the process.
 - If there is a *Scientific "guardrails"* section in the RFC, assign the **Science Reviewer** as a reviewer of the pull request and add the "science-review-required" label.
 
 #### Shepherd:
@@ -133,7 +131,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 #### Author(s):
 - Rename the RFC from `0000-my-feature.md` to `rfc####-my-feature.md` (with leading zeros) where `####` is the next available RFC number
 
-- Create a link between the approved RFC and its pull request by updating the *DCP PR* section in the RFC template and pushing the update.
+- Create a link between the approved RFC and its pull request by updating the *DCP PR* section in the RFC template and pushing the commit.
 
 - Merge the RFC pull request
 

--- a/rfcs/text/0000-rfc-process.md
+++ b/rfcs/text/0000-rfc-process.md
@@ -83,11 +83,11 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
   - Submit a pull request.
   
       For software RFCs:
-      - Add the "rfc-proposed" and the appropriate software project name _(such as "Data Store")_ labels. When the RFC impacts multiple DCP software projects, then the "Architecture" label **MUST** be the project name. *If uncertain about the appropriate project name, then **_Ask a PM_** on the HCA **#dcp-project-mgmt** slack channel*
+      - Add the "rfc-community-review" and the appropriate software project name _(such as "Data Store")_ labels. When the RFC impacts multiple DCP software projects, then the "Architecture" label **MUST** be the project name. *If uncertain about the appropriate project name, then **_Ask a PM_** on the HCA **#dcp-project-mgmt** slack channel*
 
       For governance RFCs:
         
-      - Add the "rfc-proposed" and the "Governance" labels. 
+      - Add the "rfc-community-review" and the "Governance" labels. 
 
   - Share a link to the RFC pull request for community review on the HumanCellAtlas **#dcp** slack channel
 
@@ -117,7 +117,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 #### Shepherd:
 - Monitor the community review and ensure that issues are addressed by the **Author(s)** in a reasonable time period.
 
-- When all issues are addressed and any required Science reviews are complete, summarize the review discussion for the **Approvers** in a top-level summary comment in the RFC pull request. Replace "rfc-proposed" with "rfc-final-review".
+- When all issues are addressed and any required Science reviews are complete, summarize the review discussion for the **Approvers** in a top-level summary comment in the RFC pull request. Replace "rfc-community-review" with "rfc-oversight-review".
 
 - For software RFCs, share a link to the RFC pull request for approval on the HumanCellAtlas **#tech-architecture** slack channel. Add the RFC as an agenda item to the next *DCP Architecture* meeting.
 
@@ -129,7 +129,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 #### Approvers:
 
-- At the *DCP PM* or *DCP Architecture* meeting, review the **Shepherd** summary. If there is rough consensus to approve the RFC, replace "rfc-final-review" with "rfc-approved"
+- At the *DCP PM* or *DCP Architecture* meeting, review the **Shepherd** summary. If there is rough consensus to approve the RFC, replace "rfc-oversight-review" with "rfc-approved"
 
 #### Author(s):
 - Rename the RFC from `0000-my-feature.md` to `rfc####-my-feature.md` (with leading zeros) where `####` is the next available RFC number
@@ -149,7 +149,7 @@ Where necessary, existing RFCs can be revised using the same process (a proposed
 
 #### Approvers:
 
-- At the *DCP PM* or *DCP Architecture* meeting, review the **Shepherd** summary. If there is rough consensus to reject the RFC, replace "rfc-final-review" with "rfc-declined", and close the pull request with the rationale in the comment.
+- At the *DCP PM* or *DCP Architecture* meeting, review the **Shepherd** summary. If there is rough consensus to reject the RFC, replace "rfc-oversight-review" with "rfc-declined", and close the pull request with the rationale in the comment.
 
 #### Shepherd:
 - Include the RFC rejection in *This week in DCP* status update

--- a/rfcs/text/0001-rfc-process.md
+++ b/rfcs/text/0001-rfc-process.md
@@ -1,5 +1,7 @@
 ### DCP PR:
 
+[dcp-community/rfc1](https://github.com/HumanCellAtlas/dcp-community/pull/27)
+
 # RFC Process
 
 ## Summary


### PR DESCRIPTION
**September 25**: Reviewed at DCP PM F2F meeting. Approved with changes.

**Issues that were addressed:**
* Added optional Acceptance Criteria to RFC template
* Removed references to _Thematic roadmap_ in RFC template
* Removed _This Week in DCP_ references and use existing #dcp channel for announcements (until there is more clarity about a Communications team charter)
* [Community members may escalate decisions for RFCs](https://github.com/HumanCellAtlas/dcp-community/issues/43) - previously this was limited to Authors
* [Rename rfc-proposed and rfc-final-review](https://github.com/HumanCellAtlas/dcp-community/issues/42)
  * Limited Oversight review to Approvers
* [Timebox the review process for charters and RFCs](https://github.com/HumanCellAtlas/dcp-community/issues/29)
  * Added a section on _Requesting substantial changes_ during the Oversight review

**November 15**: Approved during DCP PM call

**Tracking issues for future revisions of the RFC process** - also noted in the _Unresolved Questions_ section in the RFC:
- [Documentation for Implementing a RFC](https://github.com/HumanCellAtlas/dcp-community/issues/25)
- [Adding Informational RFCs](https://github.com/HumanCellAtlas/dcp-community/issues/30)
- [Improving community notifications for RFCs](https://github.com/HumanCellAtlas/dcp-community/issues/37)

