### PR TITLE
Updates to Charter Process

### DIFF
--- a/charters/README.md
+++ b/charters/README.md
@@ -1,10 +1,10 @@
-# Charter Guide
+# Charter Process
 
 Each HCA DCP project must have a charter that specifies its scope, responsibilities, and leadership roles.
 
 The charter process provides a simple and consistent path for new projects to be formed that align with the direction and priorities of the HCA DCP.
 
-### What are the roles in the Charter process?
+## What are the roles in the Charter process?
 
 - **Authors** are DCP community members.
 
@@ -16,29 +16,121 @@ The charter process provides a simple and consistent path for new projects to be
 
 - **Science Reviewer** is the *DCP Science PM* in coordination with *HCA Science Governance*.
 
-
-## What the process is
+## Proposing Charters
+### **Authors**:
   - Fork the HumanCellAtlas dcp-community repository
-  - Make a subdirectory named charters/`MYPROJECTNAME`
-  - Copy `charters/charter-template.md` to `charters/MYPROJECTNAME/charter.md`
+  - Make a subdirectory named `charters/MyProjectName`
+  - Copy `charters/charter-template.md` to `charters/MyProjectName/charter.md`
   - Fill in the charter with attention to detail
-  - Submit a pull request. Add the "charter-community-review" label
-  - Share a link to the pull request for community review on the HumanCellAtlas **#dcp** slack channel
-  - Feedback is added to the pull request comment thread by community members. The Science PM (or a delegate) reviews for appropriate oversight from HCA Science governance.
-  - Update the pull request in response to feedback
 
-  **For charters with software deliverables:**
+- Submit a pull request. Add the "charter-community-review" label
 
-  - Share a link to the pull request for approval on the HumanCellAtlas **#tech-architecture** slack channel when all feedback is addressed. Replace "charter-community-review" with "charter-oversight-review".
+- Add a minimum two week _last call_ for the completion of the Community review to the top-level summary comment in the charter pull request.
+
+    **EXAMPLE** 
+
+    **April 1**: Last call for community review
+
+- Request a Community review of the charter on the HumanCellAtlas **#dcp** slack channel. Include a link to the charter pull request and the last call deadline:
+
+    **EXAMPLE** 
+  
+     ***@channel**: Call for community review of the Data Store charter - https://github.com/HumanCellAtlas/dcp-community/pull/8 - Last call is April 1.*
+
+### **DCP PM**:
+
+- If there is a *Scientific "guardrails"* section in the charter:
+  - Assign the **Science Reviewer** as a reviewer of the pull request
+  - Add the "science-review-required" label
+  - Add a two week _last call_ for the completion of the Science review to the top-level summary comment in the charter pull request.
+
+    **EXAMPLE** 
+
+    **April 5**: Last call for science review
+
+   **NOTE**: *The Science review occurs in parallel to the Community review.*
+
+## Reviewing Charters
+[Reviewing Charters]: #reviewing-charters
+
+### **Approvers**:
+- May assign specific reviewers in the charter pull request
+
+### **Reviewers**:
+- Feedback is added to the pull request comment thread by community members. 
+
+### **Science Reviewer**:
+- When the feedback from the Science review is addressed, replace the "science-review-required" label with "science-review-completed".
+
+### **Authors**: 
+- Revise the charter pull request in response to feedback and push new commits
+
+- When all issues are addressed and any required Science reviews are complete:
+  - Summarize the review discussion for the **Approvers** in the top-level summary comment in the charter pull request
+  - Add a minimum one week _last call_ for the completion of the Oversight review to the top-level summary comment in the charter pull request.
+
+    **EXAMPLE** 
+
+    ~~**April 1**: Last call for community review~~
+
+    **April 22**: Last call for oversight review
+
+  - Replace "charter-community-review" with "charter-oversight-review"
+
+- For charters with software deliverables, request an Oversight review of the charter on the HumanCellAtlas **#tech-architecture** slack channel. Include a link to the charter pull request and the last call deadline
+
+  Add the charter as an agenda item to the next *DCP Architecture* meeting
+
+- For charters with governance or process deliverables, request an Oversight review of the charter on the HumanCellAtlas **#dcp-project-mgmt** slack channel. Include a link to the charter pull request and the last call deadline:
+
+    **EXAMPLE** 
+  
+     ***@channel**: Call for oversight review of the Data Store charter - https://github.com/HumanCellAtlas/dcp-community/pull/8 - Last call is April 22.*
+
+  Add the charter as an agenda item to the next *DCP PM* meeting
 
     **NOTE**: *Oversight review is limited to **Approvers**. Further community reviews during this period may be disregarded by the **Author(s)**.*
-     
-  - The request will be discussed at the next meeting of DCP Architecture (Technical Leads). If approved, the Technical Leads replace "charter-oversight-review" with "charter-approved" and merge the pull request. If rejected, the Technical Leads replace "charter-oversight-review" with "charter-rejected" and add a rationale to the pull request comment thread.
 
-  **For charters with governance or process deliverables:**
+## Approving Charters
 
-  - Share a link to the pull request for approval on the HumanCellAtlas **#dcp-project-mgmt** slack channel when all feedback is addressed. Replace "charter-community-review" with "charter-oversight-review".
+### **Approvers**:
 
-    **NOTE**: *Oversight review is limited to **Approvers**. Further community reviews during this period may be disregarded by the **Author(s)**.*
+- At the *DCP PM* or *DCP Architecture* meeting, review the summary comment. If there is rough consensus to approve the charter, replace "charter-oversight-review" with "charter-approved"
 
-  - The request will be discussed at the next meeting of DCP PM (Project Leads and Product Owners). If approved, the PM(s) replace "charter-oversight-review" with "charter-approved" and merge the pull request. If rejected, the PM(s) replace "charter-oversight-review" with "charter-rejected" and add a rationale to the pull request comment thread.
+- Merge the pull request
+
+- Announce the approval of the charter on the HumanCellAtlas #dcp slack channel. Include a link to the merged charter:
+
+  **EXAMPLE**
+
+  ***@channel**: DCP Architecture approved the Data Store charter - https://github.com/HumanCellAtlas/dcp-community/blob/master/charters/DataStore/charter.md*
+
+### Requesting substantive changes
+
+#### **Approvers**:
+
+- At the *DCP PM* or *DCP Architecture* meeting, review the summary comment. If substantial changes are requested, then replace "charter-oversight-review" with "charter-community-review".
+
+#### **Authors**:
+
+- The **Author(s)** must address the changes before requesting a community review and returning the charter to the [community review](#reviewing-charters) process.
+
+### Rejecting Charters
+
+#### Approvers:
+
+- At the *DCP PM* or *DCP Architecture* meeting, review the summary comment. If there is rough consensus to reject the charter, replace "charter-oversight-review" with "charter-rejected", and close the pull request with the rationale in the comment.
+
+- Announce the rejection of the charter on the HumanCellAtlas #dcp slack channel. Include a link to the charter pull request:
+
+  **EXAMPLE**
+
+  ***@channel**: DCP Architecture declined the Data Store charter - https://github.com/HumanCellAtlas/dcp-community/pull/8*
+
+### Appealing Charter Decisions
+
+Any DCP community member may appeal all charter decisions by **Approvers** (approval, changes requested, or rejection) by sending a message to the *DCP PM* mailing list (pm-team@data.humancellatlas.org).
+
+The message should demonstrate a clear rationale for the appeal, referencing community discussion as needed to support the position.
+
+*DCP PM* must review the appeal, resolve it in a manner of its own choosing, and respond to the original message on the *DCP PM* mailing list within two weeks.

--- a/charters/README.md
+++ b/charters/README.md
@@ -10,17 +10,23 @@ The charter process provides a simple and consistent path for new projects to be
   - Make a subdirectory named charters/`MYPROJECTNAME`
   - Copy `charters/charter-template.md` to `charters/MYPROJECTNAME/charter.md`
   - Fill in the charter with attention to detail
-  - Submit a pull request. Add the "charter-proposed" label
+  - Submit a pull request. Add the "charter-community-review" label
   - Share a link to the pull request for community review on the HumanCellAtlas **#dcp** slack channel
   - Feedback is added to the pull request comment thread by community members. The Science PM (or a delegate) reviews for appropriate oversight from HCA Science governance.
   - Update the pull request in response to feedback
 
   **For charters with software deliverables:**
 
-  - Share a link to the pull request for approval on the HumanCellAtlas **#tech-architecture** slack channel when all feedback is addressed. Replace "charter-proposed" with "charter-final-review". 
-  - The request will be discussed at the next meeting of DCP Architecture (Technical Leads). If approved, the Technical Leads replace "charter-final-review" with "charter-approved" and merge the pull request. If rejected, the Technical Leads replace "charter-final-review" with "charter-rejected" and add a rationale to the pull request comment thread.
+  - Share a link to the pull request for approval on the HumanCellAtlas **#tech-architecture** slack channel when all feedback is addressed. Replace "charter-community-review" with "charter-oversight-review".
+
+    **NOTE**: *Oversight review is limited to **Approvers**. Further community reviews during this period may be disregarded by the **Author(s)**.*
+     
+  - The request will be discussed at the next meeting of DCP Architecture (Technical Leads). If approved, the Technical Leads replace "charter-oversight-review" with "charter-approved" and merge the pull request. If rejected, the Technical Leads replace "charter-oversight-review" with "charter-rejected" and add a rationale to the pull request comment thread.
 
   **For charters with governance or process deliverables:**
 
-  - Share a link to the pull request for approval on the HumanCellAtlas **#dcp-project-mgmt** slack channel when all feedback is addressed. Replace "charter-proposed" with "charter-final-review". 
-  - The request will be discussed at the next meeting of DCP PM (Project Leads and Product Owners). If approved, the PM(s) replace "charter-final-review" with "charter-approved" and merge the pull request. If rejected, the PM(s) replace "charter-final-review" with "charter-rejected" and add a rationale to the pull request comment thread.
+  - Share a link to the pull request for approval on the HumanCellAtlas **#dcp-project-mgmt** slack channel when all feedback is addressed. Replace "charter-community-review" with "charter-oversight-review".
+
+    **NOTE**: *Oversight review is limited to **Approvers**. Further community reviews during this period may be disregarded by the **Author(s)**.*
+
+  - The request will be discussed at the next meeting of DCP PM (Project Leads and Product Owners). If approved, the PM(s) replace "charter-oversight-review" with "charter-approved" and merge the pull request. If rejected, the PM(s) replace "charter-oversight-review" with "charter-rejected" and add a rationale to the pull request comment thread.

--- a/charters/README.md
+++ b/charters/README.md
@@ -105,19 +105,19 @@ The charter process provides a simple and consistent path for new projects to be
 
   ***@channel**: DCP Architecture approved the Data Store charter - https://github.com/HumanCellAtlas/dcp-community/blob/master/charters/DataStore/charter.md*
 
-### Requesting substantive changes
+## Requesting substantive changes
 
-#### **Approvers**:
+### **Approvers**:
 
 - At the *DCP PM* or *DCP Architecture* meeting, review the summary comment. If substantial changes are requested, then replace "charter-oversight-review" with "charter-community-review".
 
-#### **Authors**:
+### **Authors**:
 
 - The **Author(s)** must address the changes before requesting a community review and returning the charter to the [community review](#reviewing-charters) process.
 
-### Rejecting Charters
+## Rejecting Charters
 
-#### Approvers:
+### **Approvers**:
 
 - At the *DCP PM* or *DCP Architecture* meeting, review the summary comment. If there is rough consensus to reject the charter, replace "charter-oversight-review" with "charter-rejected", and close the pull request with the rationale in the comment.
 
@@ -127,7 +127,7 @@ The charter process provides a simple and consistent path for new projects to be
 
   ***@channel**: DCP Architecture declined the Data Store charter - https://github.com/HumanCellAtlas/dcp-community/pull/8*
 
-### Appealing Charter Decisions
+## Appealing Charter Decisions
 
 Any DCP community member may appeal all charter decisions by **Approvers** (approval, changes requested, or rejection) by sending a message to the *DCP PM* mailing list (pm-team@data.humancellatlas.org).
 

--- a/charters/README.md
+++ b/charters/README.md
@@ -4,6 +4,18 @@ Each HCA DCP project must have a charter that specifies its scope, responsibilit
 
 The charter process provides a simple and consistent path for new projects to be formed that align with the direction and priorities of the HCA DCP.
 
+### What are the roles in the Charter process?
+
+- **Authors** are DCP community members.
+
+- **Approvers** for charters with governance or process deliverables are the Project Leads and Product Owners from *DCP PM*.
+
+- **Approvers** for charters with software deliverables are the Technical Leads from *DCP Architecture*. 
+
+- **Reviewers** are DCP community members, including both software developers and users.
+
+- **Science Reviewer** is the *DCP Science PM* in coordination with *HCA Science Governance*.
+
 
 ## What the process is
   - Fork the HumanCellAtlas dcp-community repository

--- a/charters/README.md
+++ b/charters/README.md
@@ -105,6 +105,10 @@ The charter process provides a simple and consistent path for new projects to be
 
   ***@channel**: DCP Architecture approved the Data Store charter - https://github.com/HumanCellAtlas/dcp-community/blob/master/charters/DataStore/charter.md*
 
+- Ensure that the Project Lead and Product Owner for the charter are included in *DCP PM* team mailing list and are members of the HumanCellAtlas **#dcp-project-mgmt** slack channel
+
+- Ensure the Technical Lead for the charter is included in the *DCP Architecture* mailing list and is a member of the HumanCellAtlas **#tech-architecture** slack channel
+
 ## Requesting substantive changes
 
 ### **Approvers**:

--- a/charters/charter-template.md
+++ b/charters/charter-template.md
@@ -4,7 +4,8 @@
 
 ## Description
 
-_Describe the vision of the project in **2-3** sentences. Consider this section as your "elevator pitch" to new community members._
+_Describe the vision of the project in **2-3** sentences. Consider this section as your "elevator pitch" to new community members. For software charters, indicate whether the project is specific to HCA DCP or has the potential for reuse by other communities: "The Data Store is designed to be reused in multiple projects, with HCA being the first user."_
+
 
 ## Definitions [Optional]
 


### PR DESCRIPTION
Closes #29 
Closes #36 
Closes #41 

If a charter is approved, then ensure that the charter owners are included in the PM/Architecture mailing lists and slack channels.

Editorial updates to match _RFC style_, including
* Outline matches process flow
* Included examples