### PR TITLE
Tech Lead update to Ingestion Service Charter

### DIFF
--- a/charters/IngestionService/charter.md
+++ b/charters/IngestionService/charter.md
@@ -133,7 +133,7 @@ The Ingestion Service requires oversight on which data types are required within
 
 ### Technical Lead
 
-[Simon Jupp](mailto:jupp@ebi.ac.uk) (Interim, pending new hire)
+[Justin Clark-Casey](mailto:justincc@ebi.ac.uk@ebi.ac.uk)
 
 ## Communication
 

--- a/charters/IngestionService/charter.md
+++ b/charters/IngestionService/charter.md
@@ -133,7 +133,7 @@ The Ingestion Service requires oversight on which data types are required within
 
 ### Technical Lead
 
-[Justin Clark-Casey](mailto:justincc@ebi.ac.uk@ebi.ac.uk)
+[Justin Clark-Casey](mailto:justincc@ebi.ac.uk)
 
 ## Communication
 


### PR DESCRIPTION
Updating Ingestion Service charter to replace Simon Jupp (interim tech lead) with Justin Clark-Casey