### PR TITLE
Update charter communication sections

### DIFF
--- a/charters/Architecture/charter.md
+++ b/charters/Architecture/charter.md
@@ -37,20 +37,15 @@ Operational responsibilities
     * Operational techniques and processes, including software release standard operating procedures
     * Security policies
 
-### Slack Channels
-
-HumanCellAtlas/tech-architecture: Technical implementation details of DCP projects
-and integration between them
-HumanCellAtlas/dcp-integration: Integration *workspace*
-
-## Roles
-
-### Facilitator
-
-The DCP Architecture Team Facilitator is a role that rotates among project tech leads.
-
-Current facilitator: [Sam Pierson](mailto:spierson@chanzuckerberg.com)
-
 ## Communication
 
-Team email: dcp-architecture-team@data.humancellatlas.org
+### Slack Channels
+
+[HumanCellAtlas/tech-architecture](https://humancellatlas.slack.com/messages/tech-architecture): Technical implementation details of DCP projects
+and integration between them
+
+[HumanCellAtlas/dcp-integration](https://humancellatlas.slack.com/messages/dcp-integration): Integration *workspace*
+
+### Mailing Lists
+
+[Architecture](mailto:architecture-team@data.humancellatlas.org): Team mailing list

--- a/charters/Compliance-WG/charter.md
+++ b/charters/Compliance-WG/charter.md
@@ -61,7 +61,7 @@ The Compliance Working Group will deliver:
 ## Roles
 
 ### Project Lead
-Sarah Tahiri (stahiri@broadinstitute.org)
+[Sarah Tahiri](stahiri@broadinstitute.org)
 
 ### Product Owner
 The Product Owner drives tactical execution of strategic objectives by managing the Product Backlog for the DCP project. This role is not applicable to the Compliance Working Group as it is a body responsive to the priorities assigned to it.
@@ -72,4 +72,5 @@ The Product Owner drives tactical execution of strategic objectives by managing 
 [HumanCellAtlas/dcp-security](https://humancellatlas.slack.com/messages/dcp-security): This private channel is used to discuss compliance strategy and operational security needs. If you believe you should have access to this channel, please contact the Project Lead.
 
 ### Mailing List
-Working Group email: compliance-wg@data.humancellatlas.org
+
+[Compliance](compliance-wg@data.humancellatlas.org): Working Group mailing list 

--- a/charters/DataPortal/charter.md
+++ b/charters/DataPortal/charter.md
@@ -68,6 +68,10 @@ The Data Portal is the landing site for the Human Cell Atlas (HCA) Data Coordina
 * [HumanCellAtlas/data-portal-dev](https://humancellatlas.slack.com/messages/data-portal-dev): data portal development discussions
 * [HumanCellAtlas/content-team](https://humancellatlas.slack.com/messages/content-team): data portal content development discussions
 
+## Mailing List
+
+[Data Portal](mailto:data-portal-team@data.humancellatlas.org): Team mailing list
+
 ## Github repositories
 * https://github.com/HumanCellAtlas/data-portal - the repository for the UI implementation. Use it to report issues and request new features for the Data Portal.
 * https://github.com/HumanCellAtlas/data-portal-content - the repository for the content pages of the Data Portal.

--- a/charters/PipelineExecutionService/charter.md
+++ b/charters/PipelineExecutionService/charter.md
@@ -49,10 +49,14 @@ __2020:__ Generalized and reusable service infrastructure
 
 ## Communication
 
-Team email: pipelines-team@data.humancellatlas.org 
- 
+### Slack Channels
+
 [HumanCellAtlas/data-pipelines-team](https://humancellatlas.slack.com/messages/data-pipelines-team): team discussions, a place to directly communicate to the team that works on the execution service and scientific pipelines  
 [HumanCellAtlas/data-pipelines-ci](https://humancellatlas.slack.com/messages/data-pipelines-ci): Pipeline Execution Service continuous integration status  
+
+### Mailing Lists
+
+Team email: pipelines-team@data.humancellatlas.org 
 
 ## Github repositories
 

--- a/charters/QueryService/charter.md
+++ b/charters/QueryService/charter.md
@@ -78,10 +78,13 @@ Query Service features will be developed with use cases of the following users i
 
 ## Communication
 
-Team email: dcp-query-service-team@data.humancellatlas.org
-
 ### Slack Channels
-HumanCellAtlas/query-service: Discussion of query service
+[HumanCellAtlas/query-service](https://humancellatlas.slack.com/messages/query-service): Discussion of query service
+
+### Mailing Lists
+
+Team email: query-service-team@data.humancellatlas.org
 
 ## Github repositories
-* https://github.com/HumanCellAtlas/query-service
+
+https://github.com/HumanCellAtlas/query-service

--- a/charters/charter-template.md
+++ b/charters/charter-template.md
@@ -1,7 +1,6 @@
 
 # Project Name
 
-
 ## Description
 
 _Describe the vision of the project in **2-3** sentences. Consider this section as your "elevator pitch" to new community members. For software charters, indicate whether the project is specific to HCA DCP or has the potential for reuse by other communities: "The Data Store is designed to be reused in multiple projects, with HCA being the first user."_
@@ -33,7 +32,9 @@ _Describe the major milestones and their deliverables which allow the Architectu
 
 ## Roles
 
-Recommended format for Roles: `[Name](mailto:username@example.com)`
+_Recommended format for Roles:_
+
+`[Name](mailto:username@example.com)`
 
 ### Project Lead
 
@@ -41,9 +42,22 @@ Recommended format for Roles: `[Name](mailto:username@example.com)`
 
 ### Technical Lead
 
-
 ## Communication
 
-_List the Slack Channels, Mailing Lists, and/or Discussion Forums for the Project and describe their purpose._
+### Slack Channels
+
+_Recommended format for Channels:_
+
+`[HumanCellAtlas/channel](https://humancellatlas.slack.com/messages/channel): Purpose of channel`
+
+### Mailing Lists
+
+_Recommended format for Mailing Lists:_
+
+`[Name](mailto:team@data.humancellatlas.org): Purpose of mailing list`
 
 ## Github repositories
+
+Recommended format for Repositories:
+
+`https://github.com/HumanCellAtlas/repository: Purpose of repository`

--- a/charters/charter-template.md
+++ b/charters/charter-template.md
@@ -60,4 +60,4 @@ _Recommended format for Mailing Lists:_
 
 Recommended format for Repositories:
 
-`https://github.com/HumanCellAtlas/repository: Purpose of repository`
+`[Name](https://github.com/HumanCellAtlas/repository): Purpose of repository`


### PR DESCRIPTION
Closes #45 

This are simple editorial changes to charters related to the Communication sections such as ensuring that mailing lists and slack channels are included and correct. I didn't worry too much about enforcing a standard template in earlier charters, but the charter template has been updated based on best practices for new charters.